### PR TITLE
Add UWP support

### DIFF
--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -137,7 +137,7 @@ cfg_if! {
         mod unix_backtrace;
         use self::unix_backtrace::trace as trace_imp;
         pub(crate) use self::unix_backtrace::Frame as FrameImp;
-    } else if #[cfg(all(windows, feature = "dbghelp"))] {
+    } else if #[cfg(all(windows, feature = "dbghelp", not(target_vendor = "uwp")))] {
         mod dbghelp;
         use self::dbghelp::trace as trace_imp;
         pub(crate) use self::dbghelp::Frame as FrameImp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@ mod lock {
     }
 }
 
-#[cfg(all(windows, feature = "dbghelp"))]
+#[cfg(all(windows, feature = "dbghelp", not(target_vendor = "uwp")))]
 mod dbghelp;
 #[cfg(windows)]
 mod windows;

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -428,7 +428,7 @@ cfg_if! {
         use self::coresymbolication::resolve as resolve_imp;
         use self::coresymbolication::Symbol as SymbolImp;
     } else if #[cfg(all(feature = "libbacktrace",
-                        any(unix, all(windows, target_env = "gnu")),
+                        any(unix, all(windows, target_vendor = "pc", target_env = "gnu")),
                         not(target_os = "fuchsia"),
                         not(target_os = "emscripten")))] {
         mod libbacktrace;


### PR DESCRIPTION
Hi,

This PR is associated with https://github.com/rust-lang/rust/pull/60260, and aims at fixing the build when targeting UWP.
I'd have preferred not to revert "Use LoadLibraryA instead of LoadLibraryW" but failed at using convert_utf16 to avoid declaring the byte array manually. I suppose it makes sense to not be able to use `std::` while compiling a dependency of `libstd`
The `GetModuleFileNameExA` patch requires https://sourceforge.net/p/mingw-w64/mailman/message/36680273/ which will hopefully be applied soon