### PR TITLE
Fall back to `dladdr` on Unix in more places

### DIFF
--- a/ci/azure-test-all.yml
+++ b/ci/azure-test-all.yml
@@ -41,5 +41,7 @@ steps:
     displayName: "Test backtrace (-default + dbghelp + std + verify-winapi)"
   - bash: cd ./crates/cpp_smoke_test && cargo test
     displayName: "Test cpp_smoke_test"
-  - bash: cd ./crates/without_debuginfo && cargo test
-    displayName: "Test without debuginfo"
+  - bash: cd ./crates/without_debuginfo && cargo test --features libbacktrace
+    displayName: "Test without debuginfo (libbacktrace)"
+  - bash: cd ./crates/without_debuginfo && cargo test --features 'libbacktrace coresymbolication'
+    displayName: "Test without debuginfo (coresymbolication)"

--- a/crates/without_debuginfo/Cargo.toml
+++ b/crates/without_debuginfo/Cargo.toml
@@ -4,11 +4,27 @@ version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 
-[dependencies]
-backtrace = { path = "../.." }
+[dependencies.backtrace]
+path = "../.."
+default-features = false
+features = [
+  # make sure a trace can be acquired
+  'libunwind',
+  'dbghelp',
+
+  # Allow fallback to dladdr
+  'dladdr',
+
+  # Yes, we have `std`
+  'std',
+]
 
 [profile.dev]
 debug = false
 
 [profile.test]
 debug = false
+
+[features]
+libbacktrace = ['backtrace/libbacktrace']
+coresymbolication = ['backtrace/coresymbolication']

--- a/src/symbolize/dladdr_resolve.rs
+++ b/src/symbolize/dladdr_resolve.rs
@@ -1,0 +1,51 @@
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Symbolication strategy using `dladdr`
+//!
+//! The `dladdr` API is available on most Unix implementations but it's quite
+//! basic, not handling inline frame information at all. Since it's so prevalent
+//! though we have an option to use it!
+
+use types::{BytesOrWideString, c_void};
+use symbolize::{dladdr, SymbolName, ResolveWhat};
+
+pub struct Symbol(dladdr::Symbol);
+
+impl Symbol {
+    pub fn name(&self) -> Option<SymbolName> {
+        self.0.name()
+    }
+
+    pub fn addr(&self) -> Option<*mut c_void> {
+        self.0.addr()
+    }
+
+    pub fn filename_raw(&self) -> Option<BytesOrWideString> {
+        self.0.filename_raw()
+    }
+
+    #[cfg(feature = "std")]
+    pub fn filename(&self) -> Option<&::std::path::Path> {
+        self.0.filename()
+    }
+
+    pub fn lineno(&self) -> Option<u32> {
+        self.0.lineno()
+    }
+}
+
+pub unsafe fn resolve(what: ResolveWhat, cb: &mut FnMut(&super::Symbol)) {
+    dladdr::resolve(what.address_or_ip(), &mut |sym| {
+        cb(&super::Symbol {
+            inner: Symbol(sym),
+        })
+    });
+}

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -405,6 +405,8 @@ cfg_if! {
     }
 }
 
+mod dladdr;
+
 cfg_if! {
     if #[cfg(all(windows, target_env = "msvc", feature = "dbghelp"))] {
         mod dbghelp;
@@ -435,9 +437,9 @@ cfg_if! {
     } else if #[cfg(all(unix,
                         not(target_os = "emscripten"),
                         feature = "dladdr"))] {
-        mod dladdr;
-        use self::dladdr::resolve as resolve_imp;
-        use self::dladdr::Symbol as SymbolImp;
+        mod dladdr_resolve;
+        use self::dladdr_resolve::resolve as resolve_imp;
+        use self::dladdr_resolve::Symbol as SymbolImp;
     } else {
         mod noop;
         use self::noop::resolve as resolve_imp;


### PR DESCRIPTION
Currently CoreSymbolication will fall back to `dladdr` but this also
applies the same logic to the `libbacktrace` symbolication strategy
since libbacktrace (especially on OSX) can't always get symbol name
information. Instead these platforms will all fall back to `dladdr` if
no symbol information is learned from libbacktrace.

This involved some refactoring internally since all invocations calling
the `dladdr` function are now shared instead of having three separate
ones throughout.