### PR TITLE
Leak `dbghelp.dll` like `CoreSymbolication` on OSX

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -340,7 +340,6 @@ ffi! {
         pub fn GetCurrentThread() -> HANDLE;
         pub fn RtlCaptureContext(ContextRecord: PCONTEXT) -> ();
         pub fn LoadLibraryA(a: *const i8) -> HMODULE;
-        pub fn FreeLibrary(h: HMODULE) -> BOOL;
         pub fn GetProcAddress(h: HMODULE, name: *const i8) -> FARPROC;
         pub fn OpenProcess(
             dwDesiredAccess: DWORD,


### PR DESCRIPTION
This commit updates the MSVC code to leak `dbghelp.dll` on Windows after
we initially load it. This allows for cheaper reuse between invocations
and avoids each backtrace call having to load/unload an entire DLL.
While not profiled just yet given #197 we're going to have to preserve
*something* across calls in and out of this library, so this is going to
be a first required step in any case to doing so.