### PR TITLE
Unify IP adjustments across platforms

### DIFF
--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -1,5 +1,5 @@
-use core::fmt;
 use core::ffi::c_void;
+use core::fmt;
 
 /// Inspects the current call-stack, passing all active frames into the closure
 /// provided to calculate a stack trace.

--- a/src/dbghelp.rs
+++ b/src/dbghelp.rs
@@ -23,20 +23,20 @@
 
 #![allow(non_snake_case)]
 
+use crate::windows::*;
 use core::mem;
 use core::ptr;
-use crate::windows::*;
 
 // Work around `SymGetOptions` and `SymSetOptions` not being present in winapi
 // itself. Otherwise this is only used when we're double-checking types against
 // winapi.
 #[cfg(feature = "verify-winapi")]
 mod dbghelp {
+    use crate::windows::*;
     pub use winapi::um::dbghelp::{
         StackWalk64, SymCleanup, SymFromAddrW, SymFunctionTableAccess64, SymGetLineFromAddrW64,
         SymGetModuleBase64, SymInitializeW,
     };
-    use crate::windows::*;
 
     extern "system" {
         // Not defined in winapi yet

--- a/src/symbolize/coresymbolication.rs
+++ b/src/symbolize/coresymbolication.rs
@@ -218,10 +218,6 @@ unsafe fn try_resolve(addr: *mut c_void, cb: &mut FnMut(&super::Symbol)) -> bool
         CSRelease: lib.CSRelease(),
     };
 
-    // Typically `addr` is the *next* instruction during a backtrace so we're
-    // careful to subtract one here to get the filename/line information for the
-    // previous instruction which is the one we're interested in.
-    let addr = (addr as usize - 1) as *mut c_void;
     let info = lib.CSSymbolicatorGetSourceInfoWithAddressAtTime()(cs, addr, CS_NOW);
     let sym = if info == CSREF_NULL {
         lib.CSSymbolicatorGetSymbolWithAddressAtTime()(cs, addr, CS_NOW)

--- a/src/symbolize/libbacktrace.rs
+++ b/src/symbolize/libbacktrace.rs
@@ -411,24 +411,7 @@ unsafe fn init_state() -> *mut bt::backtrace_state {
 }
 
 pub unsafe fn resolve(what: ResolveWhat, cb: &mut FnMut(&super::Symbol)) {
-    let mut symaddr = what.address_or_ip() as usize;
-
-    // IP values from stack frames are typically (always?) the instruction
-    // *after* the call that's the actual stack trace. Symbolizing this on
-    // causes the filename/line number to be one ahead and perhaps into
-    // the void if it's near the end of the function.
-    //
-    // On Windows it's pretty sure that it's always the case that the IP is one
-    // ahead (except for the final frame but oh well) and for Unix it appears
-    // that we used to use `_Unwind_GetIPInfo` which tells us if the instruction
-    // is the next or not, but it seems that on all platforms it's always the
-    // next instruction so far so let's just always assume that.
-    //
-    // In any case we'll probably have to tweak this over time, but for now this
-    // gives the most accurate backtraces.
-    if symaddr > 0 {
-        symaddr -= 1;
-    }
+    let symaddr = what.address_or_ip() as usize;
 
     // backtrace errors are currently swept under the rug
     let state = init_state();


### PR DESCRIPTION
Looks like we're just doing this everywhere, so have everyone do it the
same way during symbolication.