### PR TITLE
Implement DWARF loading for Gimli on OSX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ cpp_demangle = { default-features = false, version = "0.2.3", optional = true }
 addr2line = { version = "0.9.0", optional = true }
 findshlibs = { version = "0.4.1", optional = true }
 memmap = { version = "0.7.0", optional = true }
+goblin = { version = "0.0.22", optional = true, default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.3", optional = true }
@@ -92,7 +93,7 @@ kernel32 = []
 libbacktrace = ["backtrace-sys"]
 dladdr = []
 coresymbolication = []
-gimli-symbolize = ["addr2line", "findshlibs", "memmap" ]
+gimli-symbolize = ["addr2line", "findshlibs", "memmap", "goblin"]
 
 #=======================================
 # Methods of serialization

--- a/ci/azure-test-all.yml
+++ b/ci/azure-test-all.yml
@@ -9,6 +9,8 @@ steps:
     displayName: "Build backtrace"
   - bash: cargo test
     displayName: "Test backtrace"
+  - bash: cargo test --features 'gimli-symbolize'
+    displayName: "Test backtrace (gimli-symbolize)"
   - bash: cargo test --no-default-features
     displayName: "Test backtrace (-default)"
   - bash: cargo test --no-default-features --features 'std'
@@ -41,8 +43,6 @@ steps:
     displayName: "Test backtrace (-default + serialize-rustc + serialize-serde + std)"
   - bash: cargo test --no-default-features --features 'cpp_demangle std'
     displayName: "Test backtrace (-default + cpp_demangle + std)"
-  - bash: cargo test --no-default-features --features 'gimli-symbolize std'
-    displayName: "Test backtrace (-default + gimli-symbolize + std)"
   - bash: cargo test --no-default-features --features 'dbghelp std'
     displayName: "Test backtrace (-default + dbghelp + std)"
   - bash: cargo test --no-default-features --features 'dbghelp std verify-winapi'

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -438,9 +438,14 @@ cfg_if::cfg_if! {
         mod dbghelp;
         use self::dbghelp::resolve as resolve_imp;
         use self::dbghelp::Symbol as SymbolImp;
-    } else if #[cfg(all(feature = "std",
-                        feature = "gimli-symbolize",
-                        target_os = "linux"))] {
+    } else if #[cfg(all(
+        feature = "std",
+        feature = "gimli-symbolize",
+        any(
+            target_os = "linux",
+            target_os = "macos",
+        ),
+    ))] {
         mod gimli;
         use self::gimli::resolve as resolve_imp;
         use self::gimli::Symbol as SymbolImp;


### PR DESCRIPTION
This commit copies the logic in the libbacktrace submodule to load DWARF
debug information on OSX, namely by probing `*.dSYM` dirs and looking
for corresopnding executable files.