### PR TITLE
gimli: Don't reallocate file/name information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rustc-serialize = { version = "0.3", optional = true }
 cpp_demangle = { default-features = false, version = "0.2.3", optional = true }
 
 # Optional dependencies enabled through the `gimli-symbolize` feature
-addr2line = { version = "0.9.0", optional = true }
+addr2line = { version = "0.9.0", optional = true, default-features = false, features = ['std', 'std-object'] }
 findshlibs = { version = "0.4.1", optional = true }
 memmap = { version = "0.7.0", optional = true }
 goblin = { version = "0.0.22", optional = true, default-features = false }


### PR DESCRIPTION
Instead reuse the original storage in the original frame that we're
iterating over, avoiding an extra copy/clone per frame we otherwise
don't need.