### PR TITLE
Add prefixes to more symbols in libbacktrace

### DIFF
--- a/crates/backtrace-sys/build.rs
+++ b/crates/backtrace-sys/build.rs
@@ -94,6 +94,19 @@ fn main() {
         "backtrace_qsort",
         "backtrace_create_state",
         "backtrace_uncompress_zdebug",
+
+        // These should be `static` in C, but they aren't...
+        "macho_get_view",
+        "macho_symbol_type_relevant",
+        "macho_get_commands",
+        "macho_try_dsym",
+        "macho_try_dwarf",
+        "macho_get_addr_range",
+        "macho_get_uuid",
+        "macho_add",
+        "macho_add_symtab",
+        "macho_file_to_host_u64",
+        "macho_file_to_host_u32",
     ];
     let prefix = if cfg!(feature = "rustc-dep-of-std") {
         println!("cargo:rustc-cfg=rdos");


### PR DESCRIPTION
More symbols are exported than previously though (on OSX only) and it
looks like they in theory should be `static` in the defining file but
they aren't, so let's add them to the list of symbols to mangle when
compiling.

Closes #212