### PR TITLE
Update `findshlibs` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ cpp_demangle = { default-features = false, version = "0.2.3", optional = true }
 
 # Optional dependencies enabled through the `gimli-symbolize` feature
 addr2line = { version = "0.9.0", optional = true, default-features = false, features = ['std', 'std-object'] }
-findshlibs = { version = "0.4.1", optional = true }
+findshlibs = { version = "0.5.0", optional = true }
 memmap = { version = "0.7.0", optional = true }
 goblin = { version = "0.0.22", optional = true, default-features = false }
 


### PR DESCRIPTION
Ends up removing a very expensive `bindgen` dependency when in use, yay!