### PR TITLE
More improvements to gimli support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,18 @@ rustc-serialize = { version = "0.3", optional = true }
 cpp_demangle = { default-features = false, version = "0.2.3", optional = true }
 
 # Optional dependencies enabled through the `gimli-symbolize` feature
-addr2line = { version = "0.9.0", optional = true, default-features = false, features = ['std', 'std-object'] }
+addr2line = { version = "0.9.0", optional = true, default-features = false, features = ['std'] }
 findshlibs = { version = "0.5.0", optional = true }
 memmap = { version = "0.7.0", optional = true }
+goblin = { version = "0.0.22", optional = true, default-features = false, features = ['std'] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.3", optional = true }
+goblin = { version = "0.0.22", optional = true, default-features = false, features = ['pe32', 'pe64'] }
+[target.'cfg(target_os = "macos")'.dependencies]
+goblin = { version = "0.0.22", optional = true, default-features = false, features = ['mach32', 'mach64'] }
+[target.'cfg(not(any(target_os = "macos", windows)))'.dependencies]
+goblin = { version = "0.0.22", optional = true, default-features = false, features = ['elf32', 'elf64'] }
 
 # Each feature controls the two phases of finding a backtrace: getting a
 # backtrace and then resolving instruction pointers to symbols. The default
@@ -92,7 +98,7 @@ kernel32 = []
 libbacktrace = ["backtrace-sys"]
 dladdr = []
 coresymbolication = []
-gimli-symbolize = ["addr2line", "findshlibs", "memmap"]
+gimli-symbolize = ["addr2line", "findshlibs", "memmap", "goblin"]
 
 #=======================================
 # Methods of serialization

--- a/src/symbolize/coresymbolication.rs
+++ b/src/symbolize/coresymbolication.rs
@@ -48,17 +48,17 @@ const CSREF_NULL: CSTypeRef = CSTypeRef {
     cpp_obj: 0 as *const c_void,
 };
 
-pub enum Symbol {
+pub enum Symbol<'a> {
     Core {
         path: *const c_char,
         lineno: u32,
         name: *const c_char,
         addr: *mut c_void,
     },
-    Dladdr(dladdr::Symbol),
+    Dladdr(dladdr::Symbol<'a>),
 }
 
-impl Symbol {
+impl Symbol<'_> {
     pub fn name(&self) -> Option<SymbolName> {
         let name = match *self {
             Symbol::Core { name, .. } => name,

--- a/src/symbolize/dbghelp.rs
+++ b/src/symbolize/dbghelp.rs
@@ -35,11 +35,12 @@ use crate::windows::*;
 use crate::SymbolName;
 use core::char;
 use core::ffi::c_void;
+use core::marker;
 use core::mem;
 use core::slice;
 
 // Store an OsString on std so we can provide the symbol name and filename.
-pub struct Symbol {
+pub struct Symbol<'a> {
     name: *const [u8],
     addr: *mut c_void,
     line: Option<u32>,
@@ -48,9 +49,10 @@ pub struct Symbol {
     _filename_cache: Option<::std::ffi::OsString>,
     #[cfg(not(feature = "std"))]
     _filename_cache: (),
+    _marker: marker::PhantomData<&'a i32>,
 }
 
-impl Symbol {
+impl Symbol<'_> {
     pub fn name(&self) -> Option<SymbolName> {
         Some(SymbolName::new(unsafe { &*self.name }))
     }
@@ -209,6 +211,7 @@ unsafe fn do_resolve(
             line: lineno,
             filename,
             _filename_cache: cache(filename),
+            _marker: marker::PhantomData,
         },
     })
 }

--- a/src/symbolize/dladdr_resolve.rs
+++ b/src/symbolize/dladdr_resolve.rs
@@ -14,13 +14,13 @@
 //! basic, not handling inline frame information at all. Since it's so prevalent
 //! though we have an option to use it!
 
-use core::ffi::c_void;
+use crate::symbolize::{dladdr, ResolveWhat, SymbolName};
 use crate::types::BytesOrWideString;
-use crate::symbolize::{dladdr, SymbolName, ResolveWhat};
+use core::ffi::c_void;
 
-pub struct Symbol(dladdr::Symbol);
+pub struct Symbol<'a>(dladdr::Symbol<'a>);
 
-impl Symbol {
+impl Symbol<'_> {
     pub fn name(&self) -> Option<SymbolName> {
         self.0.name()
     }
@@ -45,8 +45,6 @@ impl Symbol {
 
 pub unsafe fn resolve(what: ResolveWhat, cb: &mut FnMut(&super::Symbol)) {
     dladdr::resolve(what.address_or_ip(), &mut |sym| {
-        cb(&super::Symbol {
-            inner: Symbol(sym),
-        })
+        cb(&super::Symbol { inner: Symbol(sym) })
     });
 }

--- a/src/symbolize/libbacktrace.rs
+++ b/src/symbolize/libbacktrace.rs
@@ -42,7 +42,7 @@ use crate::symbolize::{ResolveWhat, SymbolName};
 use crate::symbolize::dladdr;
 use crate::types::BytesOrWideString;
 
-pub enum Symbol {
+pub enum Symbol<'a> {
     Syminfo {
         pc: uintptr_t,
         symname: *const c_char,
@@ -54,10 +54,10 @@ pub enum Symbol {
         function: *const c_char,
         symname: *const c_char,
     },
-    Dladdr(dladdr::Symbol),
+    Dladdr(dladdr::Symbol<'a>),
 }
 
-impl Symbol {
+impl Symbol<'_> {
     pub fn name(&self) -> Option<SymbolName> {
         let symbol = |ptr: *const c_char| {
             unsafe {

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -188,7 +188,10 @@ where
 /// name, filename, line number, precise address, etc. Not all information is
 /// always available in a symbol, however, so all methods return an `Option`.
 pub struct Symbol {
-    inner: SymbolImp,
+    // TODO: this lifetime bound needs to be persisted eventually to `Symbol`,
+    // but that's currently a breaking change. For now this is safe since
+    // `Symbol` is only ever handed out by reference and can't be cloned.
+    inner: SymbolImp<'static>,
 }
 
 impl Symbol {
@@ -444,6 +447,7 @@ cfg_if::cfg_if! {
         any(
             target_os = "linux",
             target_os = "macos",
+            windows,
         ),
     ))] {
         mod gimli;

--- a/src/symbolize/noop.rs
+++ b/src/symbolize/noop.rs
@@ -1,17 +1,19 @@
 //! Empty symbolication strategy used to compile for platforms that have no
 //! support.
 
-use core::ffi::c_void;
+use crate::symbolize::ResolveWhat;
 use crate::types::BytesOrWideString;
 use crate::SymbolName;
-use crate::symbolize::ResolveWhat;
+use core::ffi::c_void;
+use core::marker;
 
-pub unsafe fn resolve(_addr: ResolveWhat, _cb: &mut FnMut(&super::Symbol)) {
+pub unsafe fn resolve(_addr: ResolveWhat, _cb: &mut FnMut(&super::Symbol)) {}
+
+pub struct Symbol<'a> {
+    _marker: marker::PhantomData<&'a i32>,
 }
 
-pub struct Symbol;
-
-impl Symbol {
+impl Symbol<'_> {
     pub fn name(&self) -> Option<SymbolName> {
         None
     }


### PR DESCRIPTION
* Migrate to `goblin` instead of `object` to reduce dependencies
* Disable as many features as we can along the way, slimming down dependencies
* Add rudimentary support for Windows MinGW
* Don't consult symbol tables in files and instead assume `dladdr` does
  that for us
* Add a lifetime parameter to the inner `Symbol` so the gimli bindings
  can be expressed a bit more safely.