### PR TITLE
Add prefix to one more macho_file_to_host symbol

### DIFF
--- a/crates/backtrace-sys/build.rs
+++ b/crates/backtrace-sys/build.rs
@@ -107,6 +107,7 @@ fn main() {
         "macho_add_symtab",
         "macho_file_to_host_u64",
         "macho_file_to_host_u32",
+        "macho_file_to_host_u16",
     ];
     let prefix = if cfg!(feature = "rustc-dep-of-std") {
         println!("cargo:rustc-cfg=rdos");


### PR DESCRIPTION
PR #214 intentionally mangled some macho_file_to_host
symbols which should be static in the libbacktrace
source. The commit adds one more to the list that has
been causing some issues in linking static Rust libraries
with backtrace-rs.

Closes #218.