### PR TITLE
Run gimli tests without debuginfo on Azure again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,15 @@ cpp_demangle = { default-features = false, version = "0.2.3", optional = true }
 addr2line = { version = "0.9.0", optional = true, default-features = false, features = ['std'] }
 findshlibs = { version = "0.5.0", optional = true }
 memmap = { version = "0.7.0", optional = true }
-goblin = { version = "0.0.22", optional = true, default-features = false, features = ['std'] }
+goblin = { version = "0.0.23", optional = true, default-features = false, features = ['std'] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.3", optional = true }
-goblin = { version = "0.0.22", optional = true, default-features = false, features = ['pe32', 'pe64'] }
+goblin = { version = "0.0.23", optional = true, default-features = false, features = ['pe32', 'pe64'] }
 [target.'cfg(target_os = "macos")'.dependencies]
-goblin = { version = "0.0.22", optional = true, default-features = false, features = ['mach32', 'mach64'] }
+goblin = { version = "0.0.23", optional = true, default-features = false, features = ['mach32', 'mach64'] }
 [target.'cfg(not(any(target_os = "macos", windows)))'.dependencies]
-goblin = { version = "0.0.22", optional = true, default-features = false, features = ['elf32', 'elf64'] }
+goblin = { version = "0.0.23", optional = true, default-features = false, features = ['elf32', 'elf64'] }
 
 # Each feature controls the two phases of finding a backtrace: getting a
 # backtrace and then resolving instruction pointers to symbols. The default

--- a/ci/azure-test-all.yml
+++ b/ci/azure-test-all.yml
@@ -53,7 +53,5 @@ steps:
     displayName: "Test without debuginfo (libbacktrace)"
   - bash: cd ./crates/without_debuginfo && cargo test --features 'libbacktrace coresymbolication'
     displayName: "Test without debuginfo (coresymbolication)"
-  # TODO: there's a bug on stable Rust right now (1.35.0) which prevents testing
-  # gimli here, so disable this temporarily until 1.36.0 is released.
-  # - bash: cd ./crates/without_debuginfo && cargo test --features 'libbacktrace gimli-symbolize'
-  #   displayName: "Test without debuginfo (gimli-symbolize)"
+  - bash: cd ./crates/without_debuginfo && cargo test --features 'libbacktrace gimli-symbolize'
+    displayName: "Test without debuginfo (gimli-symbolize)"


### PR DESCRIPTION
Some upstream rustc debuginfo issues should be fixed and now will likely require some gimli fixes as well