### PR TITLE
Adding a method to clear the Gimli symbol cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ addr2line = { version = "0.9.0", optional = true, default-features = false, feat
 findshlibs = { version = "0.5.0", optional = true }
 memmap = { version = "0.7.0", optional = true }
 goblin = { version = "0.0.23", optional = true, default-features = false, features = ['std'] }
-lazy_static = { version = "1.3", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.3", optional = true }
@@ -99,7 +98,7 @@ kernel32 = []
 libbacktrace = ["backtrace-sys"]
 dladdr = []
 coresymbolication = []
-gimli-symbolize = ["addr2line", "findshlibs", "memmap", "goblin", "lazy_static"]
+gimli-symbolize = ["addr2line", "findshlibs", "memmap", "goblin"]
 
 #=======================================
 # Methods of serialization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ addr2line = { version = "0.9.0", optional = true, default-features = false, feat
 findshlibs = { version = "0.5.0", optional = true }
 memmap = { version = "0.7.0", optional = true }
 goblin = { version = "0.0.23", optional = true, default-features = false, features = ['std'] }
+lazy_static = { version = "1.3", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.3", optional = true }
@@ -98,7 +99,7 @@ kernel32 = []
 libbacktrace = ["backtrace-sys"]
 dladdr = []
 coresymbolication = []
-gimli-symbolize = ["addr2line", "findshlibs", "memmap", "goblin"]
+gimli-symbolize = ["addr2line", "findshlibs", "memmap", "goblin", "lazy_static"]
 
 #=======================================
 # Methods of serialization

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,8 @@ mod symbolize;
 pub use crate::types::BytesOrWideString;
 mod types;
 
+pub use crate::symbolize::clear_symbol_cache;
+
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
         pub use crate::backtrace::trace;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ mod symbolize;
 pub use crate::types::BytesOrWideString;
 mod types;
 
+#[cfg(feature = "std")]
 pub use crate::symbolize::clear_symbol_cache;
 
 cfg_if::cfg_if! {

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -341,8 +341,8 @@ lazy_static! {
     // leverage the structures built when constructing `addr2line::Context`s to
     // get nice speedups. If we didn't have this cache, that amortization would
     // never happen, and symbolicating backtraces would be ssssllllooooowwww.
-    // static MAPPINGS_CACHE: RefCell<Vec<(PathBuf, Mapping)>> = RefCell::new(Vec::with_capacity(MAPPINGS_CACHE_SIZE));
-    static ref MAPPINGS_CACHE: Mutex<Vec<(PathBuf, Mapping)>> = Mutex::new(Vec::with_capacity(MAPPINGS_CACHE_SIZE));
+    static ref MAPPINGS_CACHE: Mutex<Vec<(PathBuf, Mapping)>> 
+        = Mutex::new(Vec::with_capacity(MAPPINGS_CACHE_SIZE));
 }
 
 pub fn clear_symbol_cache() {

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -351,7 +351,7 @@ pub unsafe fn clear_symbol_cache() {
     with_cache(|cache| cache.clear());
 }
 
-fn with_mapping_for_path<F>(path: PathBuf, f: F)
+unsafe fn with_mapping_for_path<F>(path: PathBuf, f: F)
 where
     F: FnMut(&Context<'_>),
 {

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -330,7 +330,8 @@ impl Mapping {
 
 type Cache = Vec<(PathBuf, Mapping)>;
 
-fn with_cache(f: impl FnOnce(&mut Cache)) {
+/// Warning: this function is not threadsafe and needs to be externally synchronized
+unsafe fn with_cache(f: impl FnOnce(&mut Cache)) {
     // A very small, very simple LRU cache for debug info mappings.
     //
     // The hit rate should be very high, since the typical stack doesn't cross
@@ -343,10 +344,10 @@ fn with_cache(f: impl FnOnce(&mut Cache)) {
     // never happen, and symbolicating backtraces would be ssssllllooooowwww.
     static mut MAPPINGS_CACHE: Option<Cache> = None;
 
-    unsafe { f(MAPPINGS_CACHE.get_or_insert_with(|| Vec::with_capacity(MAPPINGS_CACHE_SIZE))) }
+    f(MAPPINGS_CACHE.get_or_insert_with(|| Vec::with_capacity(MAPPINGS_CACHE_SIZE)))
 }
 
-pub fn clear_symbol_cache() {
+pub unsafe fn clear_symbol_cache() {
     with_cache(|cache| cache.clear());
 }
 

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -330,7 +330,7 @@ impl Mapping {
 
 type Cache = Vec<(PathBuf, Mapping)>;
 
-/// Warning: this function is not threadsafe and needs to be externally synchronized
+// unsafe because this is required to be externally synchronized
 unsafe fn with_cache(f: impl FnOnce(&mut Cache)) {
     // A very small, very simple LRU cache for debug info mappings.
     //
@@ -347,6 +347,7 @@ unsafe fn with_cache(f: impl FnOnce(&mut Cache)) {
     f(MAPPINGS_CACHE.get_or_insert_with(|| Vec::with_capacity(MAPPINGS_CACHE_SIZE)))
 }
 
+// unsafe because this is required to be externally synchronized
 pub unsafe fn clear_symbol_cache() {
     with_cache(|cache| cache.clear());
 }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -443,8 +443,6 @@ pub fn clear_symbol_cache() {
     clear_imp()
 }
 
-fn noop_clear_symbol_cache() {}
-
 cfg_if::cfg_if! {
     if #[cfg(all(windows, target_env = "msvc", feature = "dbghelp"))] {
         mod dbghelp;
@@ -474,6 +472,8 @@ cfg_if::cfg_if! {
         mod coresymbolication;
         use self::coresymbolication::resolve as resolve_imp;
         use self::coresymbolication::Symbol as SymbolImp;
+
+        fn noop_clear_symbol_cache() {}
         use noop_clear_symbol_cache as clear_imp;
     } else if #[cfg(all(feature = "libbacktrace",
                         any(unix, all(windows, not(target_vendor = "uwp"), target_env = "gnu")),
@@ -482,6 +482,8 @@ cfg_if::cfg_if! {
         mod libbacktrace;
         use self::libbacktrace::resolve as resolve_imp;
         use self::libbacktrace::Symbol as SymbolImp;
+        
+        fn noop_clear_symbol_cache() {}
         use noop_clear_symbol_cache as clear_imp;
     } else if #[cfg(all(unix,
                         not(target_os = "emscripten"),
@@ -489,11 +491,15 @@ cfg_if::cfg_if! {
         mod dladdr_resolve;
         use self::dladdr_resolve::resolve as resolve_imp;
         use self::dladdr_resolve::Symbol as SymbolImp;
+        
+        fn noop_clear_symbol_cache() {}
         use noop_clear_symbol_cache as clear_imp;
     } else {
         mod noop;
         use self::noop::resolve as resolve_imp;
         use self::noop::Symbol as SymbolImp;
-        use clear_symbol_cache as clear_imp;
+        
+        fn noop_clear_symbol_cache() {}
+        use noop_clear_symbol_cache as clear_imp;
     }
 }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -462,7 +462,6 @@ cfg_if::cfg_if! {
         use self::gimli::resolve as resolve_imp;
         use self::gimli::Symbol as SymbolImp;
         use self::gimli::clear_symbol_cache as clear_imp;
-        // pub use self::gimli::clear_symbol_cache as clear_symbol_cache;
     // Note that we only enable coresymbolication on iOS when debug assertions
     // are enabled because it's helpful in debug mode but it looks like apps get
     // rejected from the app store if they use this API, see #92 for more info

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -448,6 +448,7 @@ cfg_if::cfg_if! {
         mod dbghelp;
         use self::dbghelp::resolve as resolve_imp;
         use self::dbghelp::Symbol as SymbolImp;
+        fn noop_clear_symbol_cache() {}
         use noop_clear_symbol_cache as clear_imp;
     } else if #[cfg(all(
         feature = "std",

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -436,11 +436,21 @@ cfg_if::cfg_if! {
 
 mod dladdr;
 
+/// Each resolve() implementation allocates and caches several megabytes worth of symbols,
+/// clear_symbol_cache tries to reclaim that cached memory.
+/// Note: for now, only the Gimli implementation is able to clear its cache.
+pub fn clear_symbol_cache() {
+    clear_imp()
+}
+
+fn noop_clear_symbol_cache() {}
+
 cfg_if::cfg_if! {
     if #[cfg(all(windows, target_env = "msvc", feature = "dbghelp"))] {
         mod dbghelp;
         use self::dbghelp::resolve as resolve_imp;
         use self::dbghelp::Symbol as SymbolImp;
+        use noop_clear_symbol_cache as clear_imp;
     } else if #[cfg(all(
         feature = "std",
         feature = "gimli-symbolize",
@@ -453,6 +463,8 @@ cfg_if::cfg_if! {
         mod gimli;
         use self::gimli::resolve as resolve_imp;
         use self::gimli::Symbol as SymbolImp;
+        use self::gimli::clear_symbol_cache as clear_imp;
+        // pub use self::gimli::clear_symbol_cache as clear_symbol_cache;
     // Note that we only enable coresymbolication on iOS when debug assertions
     // are enabled because it's helpful in debug mode but it looks like apps get
     // rejected from the app store if they use this API, see #92 for more info
@@ -462,6 +474,7 @@ cfg_if::cfg_if! {
         mod coresymbolication;
         use self::coresymbolication::resolve as resolve_imp;
         use self::coresymbolication::Symbol as SymbolImp;
+        use noop_clear_symbol_cache as clear_imp;
     } else if #[cfg(all(feature = "libbacktrace",
                         any(unix, all(windows, not(target_vendor = "uwp"), target_env = "gnu")),
                         not(target_os = "fuchsia"),
@@ -469,15 +482,18 @@ cfg_if::cfg_if! {
         mod libbacktrace;
         use self::libbacktrace::resolve as resolve_imp;
         use self::libbacktrace::Symbol as SymbolImp;
+        use noop_clear_symbol_cache as clear_imp;
     } else if #[cfg(all(unix,
                         not(target_os = "emscripten"),
                         feature = "dladdr"))] {
         mod dladdr_resolve;
         use self::dladdr_resolve::resolve as resolve_imp;
         use self::dladdr_resolve::Symbol as SymbolImp;
+        use noop_clear_symbol_cache as clear_imp;
     } else {
         mod noop;
         use self::noop::resolve as resolve_imp;
         use self::noop::Symbol as SymbolImp;
+        use clear_symbol_cache as clear_imp;
     }
 }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -482,7 +482,7 @@ cfg_if::cfg_if! {
         mod libbacktrace;
         use self::libbacktrace::resolve as resolve_imp;
         use self::libbacktrace::Symbol as SymbolImp;
-        
+
         fn noop_clear_symbol_cache() {}
         use noop_clear_symbol_cache as clear_imp;
     } else if #[cfg(all(unix,
@@ -491,14 +491,14 @@ cfg_if::cfg_if! {
         mod dladdr_resolve;
         use self::dladdr_resolve::resolve as resolve_imp;
         use self::dladdr_resolve::Symbol as SymbolImp;
-        
+
         fn noop_clear_symbol_cache() {}
         use noop_clear_symbol_cache as clear_imp;
     } else {
         mod noop;
         use self::noop::resolve as resolve_imp;
         use self::noop::Symbol as SymbolImp;
-        
+
         fn noop_clear_symbol_cache() {}
         use noop_clear_symbol_cache as clear_imp;
     }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -489,7 +489,6 @@ cfg_if::cfg_if! {
         any(
             target_os = "linux",
             target_os = "macos",
-            windows,
         ),
     ))] {
         /// clear_symbol_cache tries to reclaim that cached memory.

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -489,7 +489,9 @@ cfg_if::cfg_if! {
         any(
             target_os = "linux",
             target_os = "macos",
+            windows,
         ),
+        not(all(windows, target_env = "msvc", feature = "dbghelp")),
     ))] {
         /// clear_symbol_cache tries to reclaim that cached memory.
         /// Note: for now, only the Gimli implementation is able to clear its cache.


### PR DESCRIPTION
As discussed in #222 , in my use case I can't really afford each process to lock hundreds of mb's per thread in the `backtrace` symbol cache.

I've added a `clear_symbol_cache()` function to the root of the crate that clears the Gimli mapping cache and uh, does nothing at all if you aren't using Gimli.
I tried to fix libbacktrace as well, but that one doesn't expose a way to free its state even in C.

I'm not that good at Rust still so this PR is more of a prototype, let me know if anything is terrible :) 
I know that a few things could be improved:
- Is it fine to take a dependency on `lazy_static`? 
- The Mutex on the static is redundant, but I couldn't placate the compiler.
- Defining `fn noop_clear_symbol_cache() {}` again for each backend is ugly.

Anyway, there it is.
 