### PR TITLE
Fix MSVC UWP builds

### DIFF
--- a/crates/backtrace-sys/src/lib.rs
+++ b/crates/backtrace-sys/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(bad_style)]
 #![no_std]
 
+#[allow(unused_extern_crates)]
 extern crate libc;
 
 #[cfg(not(empty))]

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -458,7 +458,7 @@ pub fn clear_symbol_cache() {
 mod dladdr;
 
 cfg_if::cfg_if! {
-    if #[cfg(all(windows, target_env = "msvc", feature = "dbghelp"))] {
+    if #[cfg(all(windows, target_env = "msvc", not(target_vendor = "uwp"), feature = "dbghelp"))] {
         mod dbghelp;
         use self::dbghelp::resolve as resolve_imp;
         use self::dbghelp::Symbol as SymbolImp;

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -462,6 +462,7 @@ cfg_if::cfg_if! {
         mod dbghelp;
         use self::dbghelp::resolve as resolve_imp;
         use self::dbghelp::Symbol as SymbolImp;
+        #[cfg(feature = "std")]
         unsafe fn clear_symbol_cache_imp() {}
     } else if #[cfg(all(
         feature = "std",
@@ -475,6 +476,7 @@ cfg_if::cfg_if! {
         mod gimli;
         use self::gimli::resolve as resolve_imp;
         use self::gimli::Symbol as SymbolImp;
+        #[cfg(feature = "std")]
         use self::gimli::clear_symbol_cache as clear_symbol_cache_imp;
     // Note that we only enable coresymbolication on iOS when debug assertions
     // are enabled because it's helpful in debug mode but it looks like apps get
@@ -485,6 +487,7 @@ cfg_if::cfg_if! {
         mod coresymbolication;
         use self::coresymbolication::resolve as resolve_imp;
         use self::coresymbolication::Symbol as SymbolImp;
+        #[cfg(feature = "std")]
         unsafe fn clear_symbol_cache_imp() {}
     } else if #[cfg(all(feature = "libbacktrace",
                         any(unix, all(windows, not(target_vendor = "uwp"), target_env = "gnu")),
@@ -493,6 +496,7 @@ cfg_if::cfg_if! {
         mod libbacktrace;
         use self::libbacktrace::resolve as resolve_imp;
         use self::libbacktrace::Symbol as SymbolImp;
+        #[cfg(feature = "std")]
         unsafe fn clear_symbol_cache_imp() {}
     } else if #[cfg(all(unix,
                         not(target_os = "emscripten"),
@@ -500,11 +504,13 @@ cfg_if::cfg_if! {
         mod dladdr_resolve;
         use self::dladdr_resolve::resolve as resolve_imp;
         use self::dladdr_resolve::Symbol as SymbolImp;
+        #[cfg(feature = "std")]
         unsafe fn clear_symbol_cache_imp() {}
     } else {
         mod noop;
         use self::noop::resolve as resolve_imp;
         use self::noop::Symbol as SymbolImp;
+        #[cfg(feature = "std")]
         unsafe fn clear_symbol_cache_imp() {}
     }
 }


### PR DESCRIPTION
Unmodified backtrace-rs breaks the rustc build when building a standard library for an experimental MSVC UWP target. These changes allow the build to proceed.