### PR TITLE
gimli: Only iterate shared libraries once

### DIFF
--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -18,8 +18,9 @@ use findshlibs::{self, Segment, SharedLibrary};
 use libc::c_void;
 use memmap::Mmap;
 use std::env;
+use std::ffi::OsString;
 use std::fs::File;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::prelude::v1::*;
 
 const MAPPINGS_CACHE_SIZE: usize = 4;
@@ -318,46 +319,128 @@ impl Mapping {
                 .next()
         }
     }
-
-    // Ensure the 'static lifetimes don't leak.
-    fn rent<F>(&self, mut f: F)
-    where
-        F: FnMut(&Context<'_>),
-    {
-        f(&self.cx)
-    }
 }
 
-type Cache = Vec<(PathBuf, Mapping)>;
+#[derive(Default)]
+struct Cache {
+    /// All known shared libraries that have been loaded.
+    libraries: Vec<Library>,
 
-// unsafe because this is required to be externally synchronized
-unsafe fn with_cache(f: impl FnOnce(&mut Cache)) {
-    // A very small, very simple LRU cache for debug info mappings.
-    //
-    // The hit rate should be very high, since the typical stack doesn't cross
-    // between many shared libraries.
-    //
-    // The `addr2line::Context` structures are pretty expensive to create. Its
-    // cost is expected to be amortized by subsequent `locate` queries, which
-    // leverage the structures built when constructing `addr2line::Context`s to
-    // get nice speedups. If we didn't have this cache, that amortization would
-    // never happen, and symbolicating backtraces would be ssssllllooooowwww.
-    static mut MAPPINGS_CACHE: Option<Cache> = None;
+    /// Mappings cache where we retain parsed dwarf information.
+    ///
+    /// This list has a fixed capacity for its entire liftime which never
+    /// increases. The `usize` element of each pair is an index into `libraries`
+    /// above where `usize::max_value()` represents the current executable. The
+    /// `Mapping` is corresponding parsed dwarf information.
+    ///
+    /// Note that this is basically an LRU cache and we'll be shifting things
+    /// around in here as we symbolize addresses.
+    mappings: Vec<(usize, Mapping)>,
+}
 
-    f(MAPPINGS_CACHE.get_or_insert_with(|| Vec::with_capacity(MAPPINGS_CACHE_SIZE)))
+struct Library {
+    name: OsString,
+    segments: Vec<LibrarySegment>,
+    bias: findshlibs::Bias,
+}
+
+struct LibrarySegment {
+    len: usize,
+    stated_virtual_memory_address: findshlibs::Svma,
 }
 
 // unsafe because this is required to be externally synchronized
 pub unsafe fn clear_symbol_cache() {
-    with_cache(|cache| cache.clear());
+    Cache::with_global(|cache| cache.mappings.clear());
 }
 
-unsafe fn with_mapping_for_path<F>(path: PathBuf, f: F)
-where
-    F: FnMut(&Context<'_>),
-{
-    with_cache(|cache| {
-        let idx = cache.iter().position(|&(ref p, _)| p == &path);
+impl Cache {
+    fn new() -> Cache {
+        let mut libraries = Vec::new();
+        // Iterate over all loaded shared libraries and cache information we
+        // learn about them. This way we only load information here once instead
+        // of once per symbol.
+        findshlibs::TargetSharedLibrary::each(|so| {
+            use findshlibs::IterationControl::*;
+            libraries.push(Library {
+                name: so.name().to_owned(),
+                segments: so
+                    .segments()
+                    .map(|s| LibrarySegment {
+                        len: s.len(),
+                        stated_virtual_memory_address: s.stated_virtual_memory_address(),
+                    })
+                    .collect(),
+                bias: so.virtual_memory_bias(),
+            });
+            Continue
+        });
+
+        Cache {
+            mappings: Vec::with_capacity(MAPPINGS_CACHE_SIZE),
+            libraries,
+        }
+    }
+
+    // unsafe because this is required to be externally synchronized
+    unsafe fn with_global(f: impl FnOnce(&mut Self)) {
+        // A very small, very simple LRU cache for debug info mappings.
+        //
+        // The hit rate should be very high, since the typical stack doesn't cross
+        // between many shared libraries.
+        //
+        // The `addr2line::Context` structures are pretty expensive to create. Its
+        // cost is expected to be amortized by subsequent `locate` queries, which
+        // leverage the structures built when constructing `addr2line::Context`s to
+        // get nice speedups. If we didn't have this cache, that amortization would
+        // never happen, and symbolicating backtraces would be ssssllllooooowwww.
+        static mut MAPPINGS_CACHE: Option<Cache> = None;
+
+        f(MAPPINGS_CACHE.get_or_insert_with(|| Cache::new()))
+    }
+
+    fn avma_to_svma(&self, addr: *const u8) -> Option<(usize, findshlibs::Svma)> {
+        // Note that for now `findshlibs` is unimplemented on Windows, so we
+        // just unhelpfully assume that the address is an SVMA. Surprisingly it
+        // seems to at least somewhat work on Wine on Linux though...
+        //
+        // This probably means ASLR on Windows is busted.
+        if cfg!(windows) {
+            let addr = findshlibs::Svma(addr);
+            return Some((usize::max_value(), addr));
+        }
+
+        self.libraries
+            .iter()
+            .enumerate()
+            .filter_map(|(i, lib)| {
+                // First up, test if this `lib` has any segment containing the
+                // `addr` (handling relocation). If this check passes then we
+                // can continue below and actually translate the address.
+                //
+                // Note that this is an inlining of `contains_avma` in the
+                // `findshlibs` crate here.
+                if !lib.segments.iter().any(|s| {
+                    let svma = s.stated_virtual_memory_address;
+                    let start = unsafe { svma.0.offset(lib.bias.0) as usize };
+                    let end = start + s.len;
+                    let address = addr as usize;
+                    start <= address && address < end
+                }) {
+                    return None;
+                }
+
+                // Now that we know `lib` contains `addr`, do the equiavlent of
+                // `avma_to_svma` in the `findshlibs` crate.
+                let reverse_bias = -lib.bias.0;
+                let svma = findshlibs::Svma(unsafe { addr.offset(reverse_bias) });
+                Some((i, svma))
+            })
+            .next()
+    }
+
+    fn mapping_for_lib<'a>(&'a mut self, lib: usize) -> Option<&'a Context<'a>> {
+        let idx = self.mappings.iter().position(|(idx, _)| *idx == lib);
 
         // Invariant: after this conditional completes without early returning
         // from an error, the cache entry for this path is at index 0.
@@ -365,27 +448,35 @@ where
         if let Some(idx) = idx {
             // When the mapping is already in the cache, move it to the front.
             if idx != 0 {
-                let entry = cache.remove(idx);
-                cache.insert(0, entry);
+                let entry = self.mappings.remove(idx);
+                self.mappings.insert(0, entry);
             }
         } else {
             // When the mapping is not in the cache, create a new mapping,
             // insert it into the front of the cache, and evict the oldest cache
             // entry if necessary.
-            let mapping = match Mapping::new(&path) {
-                None => return,
-                Some(m) => m,
+            let storage;
+            let path = match self.libraries.get(lib) {
+                Some(lib) => &lib.name,
+                None => {
+                    storage = env::current_exe().ok()?.into();
+                    &storage
+                }
             };
+            let mapping = Mapping::new(path.as_ref())?;
 
-            if cache.len() == MAPPINGS_CACHE_SIZE {
-                cache.pop();
+            if self.mappings.len() == MAPPINGS_CACHE_SIZE {
+                self.mappings.pop();
             }
 
-            cache.insert(0, (path, mapping));
+            self.mappings.insert(0, (lib, mapping));
         }
 
-        cache[0].1.rent(f);
-    });
+        let cx: &'a Context<'static> = &self.mappings[0].1.cx;
+        // don't leak the `'static` lifetime, make sure it's scoped to just
+        // ourselves
+        Some(unsafe { mem::transmute::<&'a Context<'static>, &'a Context<'a>>(cx) })
+    }
 }
 
 pub unsafe fn resolve(what: ResolveWhat, cb: &mut FnMut(&super::Symbol)) {
@@ -396,65 +487,23 @@ pub unsafe fn resolve(what: ResolveWhat, cb: &mut FnMut(&super::Symbol)) {
         called: false,
     };
 
-    // First, find the file containing the segment that the given AVMA (after
-    // relocation) address falls within. Use the containing segment to compute
-    // the SVMA (before relocation) address.
-    //
-    // Note that the OS APIs that `SharedLibrary::each` is implemented with hold
-    // a lock for the duration of the `each` call, so we want to keep this
-    // section as short as possible to avoid contention with other threads
-    // capturing backtraces.
-    //
-    // Also note that for now `findshlibs` is unimplemented on Windows, so we
-    // just unhelpfully assume that the address is an SVMA. Surprisingly it
-    // seems to at least somewhat work on Wine on Linux though...
-    let (addr, path) = if cfg!(windows) {
-        let addr = findshlibs::Svma(addr as *mut u8 as *const u8);
-        (addr, String::new())
-    } else {
-        let addr = findshlibs::Avma(addr as *mut u8 as *const u8);
-        let mut so_info = None;
-        findshlibs::TargetSharedLibrary::each(|so| {
-            use findshlibs::IterationControl::*;
-
-            for segment in so.segments() {
-                if segment.contains_avma(so, addr) {
-                    let addr = so.avma_to_svma(addr);
-                    let path = so.name().to_string_lossy();
-                    so_info = Some((addr, path.to_string()));
-                    return Break;
-                }
-            }
-
-            Continue
-        });
-        match so_info {
+    Cache::with_global(|cache| {
+        let (lib, addr) = match cache.avma_to_svma(addr as *const u8) {
+            Some(pair) => pair,
             None => return,
-            Some((a, p)) => (a, p),
-        }
-    };
+        };
 
-    // Second, fixup the path. Empty path means that this address falls within
-    // the main executable, not a shared library.
-    let path = if path.is_empty() {
-        match env::current_exe() {
-            Err(_) => return,
-            Ok(p) => p,
-        }
-    } else {
-        PathBuf::from(path)
-    };
-
-    // Finally, get a cached mapping or create a new mapping for this file, and
-    // evaluate the DWARF info to find the file/line/name for this address.
-    with_mapping_for_path(path, |cx| {
-        let mut called = false;
+        // Finally, get a cached mapping or create a new mapping for this file, and
+        // evaluate the DWARF info to find the file/line/name for this address.
+        let cx = match cache.mapping_for_lib(lib) {
+            Some(cx) => cx,
+            None => return,
+        };
         if let Ok(mut frames) = cx.dwarf.find_frames(addr.0 as u64) {
             while let Ok(Some(mut frame)) = frames.next() {
                 let function = frame.function.take();
                 let name = function.as_ref().and_then(|f| f.raw_name().ok());
                 let name = name.as_ref().map(|n| n.as_bytes());
-                called = true;
                 cb.call(Symbol::Frame {
                     addr: addr.0 as *mut c_void,
                     frame,
@@ -463,7 +512,7 @@ pub unsafe fn resolve(what: ResolveWhat, cb: &mut FnMut(&super::Symbol)) {
             }
         }
 
-        if !called {
+        if !cb.called {
             if let Some(name) = cx.object.search_symtab(addr.0 as u64) {
                 cb.call(Symbol::Symtab {
                     addr: addr.0 as *mut c_void,


### PR DESCRIPTION
This commit updates the gimli implementation to iterate over all shared
libraries only once, caching information about them to get processed
later. This information is usually static for the lifetime of the
program, and this improves the performance of resolving a backtrace
significantly in some situations (by up to 30%).

The organization of the gimli backend has been updated to reflect this
cache where `Cache` is now a dedicated type with methods hanging off it.
Some helper code had to be duplicated from the `findshlibs` crate to do
this entirely.

cc #232