### PR TITLE
gimli: Look at object dynamic symbol tables 

### DIFF
--- a/src/symbolize/dladdr.rs
+++ b/src/symbolize/dladdr.rs
@@ -63,7 +63,9 @@ cfg_if::cfg_if! {
                 inner: mem::zeroed(),
                 _marker: marker::PhantomData,
             };
-            if libc::dladdr(addr as *mut _, &mut info.inner) != 0 {
+            // Skip null addresses to avoid calling into libc and having it do
+            // things with the dynamic symbol table for no reason.
+            if !addr.is_null() && libc::dladdr(addr as *mut _, &mut info.inner) != 0 {
                 cb(info)
             }
         }


### PR DESCRIPTION
This commit updates the gimli parsing code to consult the dynamic symbol
table for each object in addition to the normal symbol table. This also
starts filtering symbols in the same way libbacktrace does to ensure
symbolication doesn't go down the rabbit hole with non-function
symbols.

This overall removes the need for gimli to fall back to dladdr
functionally for now. In testing this speeds up benchmarks by 15% by
avoiding calling `dladdr` in libc.