### PR TITLE
Fix some cases of concurrent panics and backtraces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,3 +152,8 @@ edition = '2018'
 name = "accuracy"
 required-features = ["std", "dbghelp", "libbacktrace", "libunwind"]
 edition = '2018'
+
+[[test]]
+name = "concurrent-panics"
+required-features = ['std']
+harness = false

--- a/tests/concurrent-panics.rs
+++ b/tests/concurrent-panics.rs
@@ -1,0 +1,71 @@
+use std::env;
+use std::panic;
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
+use std::sync::Arc;
+use std::thread;
+
+const PANICS: usize = 100;
+const THREADS: usize = 8;
+const VAR: &str = "__THE_TEST_YOU_ARE_LUKE";
+
+fn main() {
+    // These run in docker containers on CI where they can't re-exec the test,
+    // so just skip these for CI. No other reason this can't run on those
+    // platforms though.
+    if cfg!(unix) && (cfg!(target_arch = "arm") || cfg!(target_arch = "aarch64")) {
+        return;
+    }
+
+    if env::var(VAR).is_err() {
+        parent();
+    } else {
+        child();
+    }
+}
+
+fn parent() {
+    let me = env::current_exe().unwrap();
+    let result = Command::new(&me)
+        .env("RUST_BACKTRACE", "1")
+        .env(VAR, "1")
+        .output()
+        .unwrap();
+    if result.status.success() {
+        println!("test result: ok");
+        return;
+    }
+    println!("stdout:\n{}", String::from_utf8_lossy(&result.stdout));
+    println!("stderr:\n{}", String::from_utf8_lossy(&result.stderr));
+    println!("code: {}", result.status);
+    panic!();
+}
+
+fn child() {
+    let done = Arc::new(AtomicBool::new(false));
+    let done2 = done.clone();
+    let a = thread::spawn(move || {
+        while !done2.load(SeqCst) {
+            format!("{:?}", backtrace::Backtrace::new());
+        }
+    });
+
+    let threads = (0..THREADS)
+        .map(|_| {
+            thread::spawn(|| {
+                for _ in 0..PANICS {
+                    assert!(panic::catch_unwind(|| {
+                        panic!();
+                    })
+                    .is_err());
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    for thread in threads {
+        thread.join().unwrap();
+    }
+
+    done.store(true, SeqCst);
+    a.join().unwrap();
+}


### PR DESCRIPTION
This commit adds an awful hack to this crate to attempt to mitigate the
issue of concurrently generating a backtrace in the standard library via
`RUST_BACKTRACE=1` and also generating a backtrace with this crate. On
Windows the system library that we used for doing this is required to be
single-threaded but we don't actually provide such a guarantee when
using this crate because we can't easily synchronize with the standard
library.

The hack applied in this crate is to use a *panic hook* to inject
ourselves into the panic process and ensure that panics are synchronized
with generating a backtrace. The commit itself has a lot more comments
about how this is not a complete nor a bullet-proof solution. It's just
sort of the best approximation I think we can do with stable Rust.
Long-term we're going to want to have some sort of official stable API
in libstd to do this coordination.

cc #230