### PR TITLE
Fix concurrent panics and backtraces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ verify-winapi = [
   'winapi/libloaderapi',
   'winapi/minwindef',
   'winapi/processthreadsapi',
+  'winapi/synchapi',
   'winapi/winbase',
   'winapi/winnt',
 ]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -28,6 +28,7 @@ cfg_if::cfg_if! {
             pub use winapi::um::winnt::*;
             pub use winapi::um::fileapi::*;
             pub use winapi::um::minwinbase::*;
+            pub use winapi::um::synchapi::*;
         }
     } else {
         pub use core::ffi::c_void;
@@ -314,6 +315,7 @@ ffi! {
     pub const FILE_SHARE_WRITE: DWORD = 0x2;
     pub const OPEN_EXISTING: DWORD = 0x3;
     pub const GENERIC_READ: DWORD = 0x80000000;
+    pub const INFINITE: DWORD = !0;
 
     pub type DWORD = u32;
     pub type PDWORD = *mut u32;
@@ -363,6 +365,17 @@ ffi! {
             dwFlagsAndAttributes: DWORD,
             hTemplateFile: HANDLE,
         ) -> HANDLE;
+        pub fn CreateMutexA(
+            attrs: LPSECURITY_ATTRIBUTES,
+            initial: BOOL,
+            name: LPCSTR,
+        ) -> HANDLE;
+        pub fn ReleaseMutex(hMutex: HANDLE) -> BOOL;
+        pub fn WaitForSingleObjectEx(
+            hHandle: HANDLE,
+            dwMilliseconds: DWORD,
+            bAlertable: BOOL,
+        ) -> DWORD;
     }
 }
 


### PR DESCRIPTION
On Windows `dbghelp.dll` is required to be used from only one thread at
a time, and while this crate provides that guarantee this crate does not
synchronize with itself in the standard library. This commit solves this
issue by using a Windows-specific trick by creating a named mutex for
synchronization.

When this crate is updated in the standard library it means that the
named mutex here will be shared with the standard library, so the
standard library and this crate should be sharing the same
synchronization primitive and should be able to coordinate calls to
`dbghelp.dll`.

More details are included in the commit itself, but this should...

Closes #230