### PR TITLE
Make the main crate workspace crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ autoexamples = true
 autotests = true
 edition = "2018"
 
+[workspace]
+members = ['crates/cpp_smoke_test']
+exclude = ['crates/without_debuginfo']
+
 [dependencies]
 cfg-if = "0.1.6"
 rustc-demangle = "0.1.4"

--- a/crates/backtrace-sys/build.rs
+++ b/crates/backtrace-sys/build.rs
@@ -95,7 +95,6 @@ fn main() {
         "backtrace_qsort",
         "backtrace_create_state",
         "backtrace_uncompress_zdebug",
-
         // These should be `static` in C, but they aren't...
         "macho_get_view",
         "macho_symbol_type_relevant",

--- a/crates/cpp_smoke_test/Cargo.toml
+++ b/crates/cpp_smoke_test/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 build = "build.rs"
 
 [build-dependencies]
-gcc = "0.3.43"
+cc = "1.0"
 
 [dependencies]
 backtrace = { path = "../..", features = ["cpp_demangle"] }

--- a/crates/cpp_smoke_test/build.rs
+++ b/crates/cpp_smoke_test/build.rs
@@ -1,5 +1,3 @@
-extern crate gcc;
-
 fn main() {
     compile_cpp();
 }
@@ -7,7 +5,7 @@ fn main() {
 fn compile_cpp() {
     println!("cargo:rerun-if-changed=cpp/trampoline.cpp");
 
-    gcc::Config::new()
+    cc::Build::new()
         .cpp(true)
         .debug(true)
         .opt_level(0)

--- a/crates/cpp_smoke_test/src/lib.rs
+++ b/crates/cpp_smoke_test/src/lib.rs
@@ -1,3 +1,2 @@
 #[test]
-fn it_works() {
-}
+fn it_works() {}

--- a/crates/cpp_smoke_test/tests/smoke.rs
+++ b/crates/cpp_smoke_test/tests/smoke.rs
@@ -1,7 +1,7 @@
 extern crate cpp_smoke_test;
 extern crate backtrace;
 
-use std::sync::atomic::{ATOMIC_BOOL_INIT, AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 extern "C" {
     fn cpp_trampoline(func: extern "C" fn()) -> ();
@@ -11,7 +11,7 @@ extern "C" {
 #[ignore] // fixme(fitzgen/cpp_demangle#73)
 #[cfg(not(target_os = "windows"))]
 fn smoke_test_cpp() {
-    static RAN_ASSERTS: AtomicBool = ATOMIC_BOOL_INIT;
+    static RAN_ASSERTS: AtomicBool = AtomicBool::new(false);
 
     extern "C" fn assert_cpp_frames() {
         let mut physical_frames = Vec::new();

--- a/crates/cpp_smoke_test/tests/smoke.rs
+++ b/crates/cpp_smoke_test/tests/smoke.rs
@@ -1,5 +1,5 @@
-extern crate cpp_smoke_test;
 extern crate backtrace;
+extern crate cpp_smoke_test;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -26,7 +26,8 @@ fn smoke_test_cpp() {
             physical_frames.len() < 4
         });
 
-        let names: Vec<_> = physical_frames.into_iter()
+        let names: Vec<_> = physical_frames
+            .into_iter()
             .flat_map(|ip| {
                 let mut logical_frame_names = vec![];
 
@@ -36,8 +37,10 @@ fn smoke_test_cpp() {
                     logical_frame_names.push(demangled);
                 });
 
-                assert!(!logical_frame_names.is_empty(),
-                        "Should have resolved at least one symbol for the physical frame");
+                assert!(
+                    !logical_frame_names.is_empty(),
+                    "Should have resolved at least one symbol for the physical frame"
+                );
 
                 logical_frame_names
             })


### PR DESCRIPTION
That way when testing `backtrace-sys` it all builds into the same
location