### PR TITLE
vxWorks: use rtpInfoGet() to get rtp executable path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backtrace"
-version = "0.3.36"
+version = "0.3.37"
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
r? @alexcrichton 