### PR TITLE
Fix type error in SGX backtrace printing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [wasm32-unknown-unknown, x86_64-fuchsia]
+        target: [wasm32-unknown-unknown, wasm32-wasi, x86_64-fuchsia, x86_64-fortanix-unknown-sgx]
     steps:
     - uses: actions/checkout@master
       with:

--- a/src/print.rs
+++ b/src/print.rs
@@ -198,8 +198,8 @@ impl BacktraceFrameFmt<'_, '_, '_> {
         // address here, which could be later mapped to correct function.
         #[cfg(all(feature = "std", target_env = "sgx"))]
         {
-            frame_ip =
-                usize::wrapping_sub(frame_ip, std::os::fortanix_sgx::mem::image_base() as _) as _;
+            let image_base = std::os::fortanix_sgx::mem::image_base();
+            frame_ip = usize::wrapping_sub(frame_ip as usize, image_base as _) as _;
         }
 
         // Print the index of the frame as well as the optional instruction


### PR DESCRIPTION
Also adds the target to CI to prevent this from happening again in the future.