### PR TITLE
Add `format_trace(impl fmt::Write, PrintFmt)` 

### DIFF
--- a/examples/backtrace.rs
+++ b/examples/backtrace.rs
@@ -1,7 +1,17 @@
 extern crate backtrace;
 
-use backtrace::Backtrace;
+use backtrace::{format_trace, Backtrace, PrintFmt};
 
 fn main() {
-    println!("{:?}", Backtrace::new());
+    print!("{:?}", Backtrace::new());
+    format_trace(Utf8(std::io::stdout()), PrintFmt::Short).unwrap();
+    format_trace(Utf8(std::io::stdout()), PrintFmt::Full).unwrap();
+}
+
+struct Utf8<W>(W);
+
+impl<W: std::io::Write> std::fmt::Write for Utf8<W> {
+    fn write_str(&mut self, s: &str) -> Result<(), std::fmt::Error> {
+        self.0.write_all(s.as_bytes()).map_err(|_| std::fmt::Error)
+    }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,115 @@
+use crate::PrintFmt;
+use core::ffi::c_void;
+use core::fmt::{self, Write};
+
+/// Inspects the current call-stack, formatting it to `stream`.
+///
+/// This is similar to `write!(stream, "{:?}", Backtrace::new())`,
+/// but avoids memory allocation.
+/// This can be useful in a signal handler, where allocation may cause deadlocks.
+///
+/// # Required features
+///
+/// This function requires the `std` feature of the `backtrace` crate to be
+/// enabled, and the `std` feature is enabled by default.
+///
+/// # Panics
+///
+/// This function strives to never panic, but if the `cb` provided panics then
+/// some platforms will force a double panic to abort the process. Some
+/// platforms use a C library which internally uses callbacks which cannot be
+/// unwound through, so panicking from `cb` may trigger a process abort.
+#[cfg(feature = "std")]
+#[inline(never)]
+pub fn format_trace<W: Write>(mut stream: W, mode: PrintFmt) -> fmt::Result {
+    let _guard = crate::lock::lock();
+    write!(
+        stream,
+        "{:?}",
+        FormatTrace {
+            mode,
+            entry_point_address: format_trace::<W> as *mut c_void,
+        }
+    )
+}
+
+/// Same as `format_trace`, only unsafe as it's unsynchronized.
+///
+/// This function does not have synchronization guarentees but is available
+/// when the `std` feature of this crate isn't compiled in. See the `format_trace`
+/// function for more documentation and examples.
+///
+/// # Panics
+///
+/// See information on `format_trace` for caveats on `stream` panicking.
+#[inline(never)]
+pub unsafe fn format_trace_unsynchronized<W: Write>(mut stream: W, mode: PrintFmt) -> fmt::Result {
+    write!(
+        stream,
+        "{:?}",
+        FormatTrace {
+            mode,
+            entry_point_address: format_trace_unsynchronized::<W> as *mut c_void,
+        }
+    )
+}
+
+struct FormatTrace {
+    mode: PrintFmt,
+    entry_point_address: *mut c_void,
+}
+
+impl fmt::Debug for FormatTrace {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let mut print_fn_frame = -1;
+        if let PrintFmt::Short = self.mode {
+            let mut i = 0;
+            let each_frame = |frame: &crate::Frame| {
+                let found = frame.symbol_address() == self.entry_point_address;
+                if found {
+                    print_fn_frame = i;
+                }
+                i += 1;
+                !found
+            };
+            // Safety: either synchronization is take care of in `format_trace`,
+            // or `unsafe fn format_trace_unsynchronized` was called.
+            unsafe { crate::trace_unsynchronized(each_frame) }
+        }
+
+        let mut print_path =
+            |f: &mut fmt::Formatter, path: crate::BytesOrWideString| fmt::Display::fmt(&path, f);
+        let mut f = crate::BacktraceFmt::new(fmt, self.mode, &mut print_path);
+        f.add_context()?;
+        let mut result = Ok(());
+        let mut i = 0;
+        let each_frame = |frame: &crate::Frame| {
+            let skip = i <= print_fn_frame;
+            i += 1;
+            if skip {
+                return true;
+            }
+
+            let mut frame_fmt = f.frame();
+            let mut any_symbol = false;
+            let each_symbol = |symbol: &crate::Symbol| {
+                any_symbol = true;
+                if let Err(e) = frame_fmt.symbol(frame, symbol) {
+                    result = Err(e)
+                }
+            };
+            // Safety: same as above
+            unsafe { crate::resolve_frame_unsynchronized(frame, each_symbol) }
+            if !any_symbol {
+                if let Err(e) = frame_fmt.print_raw(frame.ip(), None, None, None) {
+                    result = Err(e)
+                }
+            }
+            result.is_ok()
+        };
+        // Safety: same as above
+        unsafe { crate::trace_unsynchronized(each_frame) }
+        result?;
+        f.finish()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,26 @@ impl Drop for Bomb {
     }
 }
 
+fn format_utf8_lossy(mut bytes: &[u8], f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    loop {
+        match core::str::from_utf8(bytes) {
+            Ok(s) => {
+                f.write_str(s)?;
+                break;
+            }
+            Err(err) => {
+                f.write_str("\u{FFFD}")?;
+
+                match err.error_len() {
+                    Some(len) => bytes = &bytes[err.valid_up_to() + len..],
+                    None => break,
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 #[allow(dead_code)]
 #[cfg(feature = "std")]
 mod lock {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,9 @@ extern crate std;
 pub use crate::backtrace::{trace_unsynchronized, Frame};
 mod backtrace;
 
+pub use crate::format::format_trace_unsynchronized;
+mod format;
+
 pub use crate::symbolize::resolve_frame_unsynchronized;
 pub use crate::symbolize::{resolve_unsynchronized, Symbol, SymbolName};
 mod symbolize;
@@ -92,6 +95,7 @@ pub use print::{BacktraceFmt, BacktraceFrameFmt, PrintFmt};
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
         pub use crate::backtrace::trace;
+        pub use crate::format::format_trace;
         pub use crate::symbolize::{resolve, resolve_frame};
         pub use crate::capture::{Backtrace, BacktraceFrame, BacktraceSymbol};
         mod capture;


### PR DESCRIPTION
This is similar to `write!(stream, "{:?}", Backtrace::new())`, but avoids memory allocation. This can be useful in a signal handler, where allocation may cause deadlocks.