### PR TITLE
Bound target_env = sgx with target_vendor = fortanix

### DIFF
--- a/src/backtrace/dbghelp.rs
+++ b/src/backtrace/dbghelp.rs
@@ -21,10 +21,10 @@
 
 #![allow(bad_style)]
 
-use core::ffi::c_void;
-use core::mem;
 use crate::dbghelp;
 use crate::windows::*;
+use core::ffi::c_void;
+use core::mem;
 
 #[derive(Clone, Copy)]
 pub enum Frame {

--- a/src/backtrace/libunwind.rs
+++ b/src/backtrace/libunwind.rs
@@ -48,9 +48,7 @@ impl Frame {
             Frame::Raw(ctx) => ctx,
             Frame::Cloned { ip, .. } => return ip,
         };
-        unsafe {
-            uw::_Unwind_GetIP(ctx) as *mut c_void
-        }
+        unsafe { uw::_Unwind_GetIP(ctx) as *mut c_void }
     }
 
     pub fn symbol_address(&self) -> *mut c_void {
@@ -87,8 +85,10 @@ impl Clone for Frame {
 pub unsafe fn trace(mut cb: &mut FnMut(&super::Frame) -> bool) {
     uw::_Unwind_Backtrace(trace_fn, &mut cb as *mut _ as *mut _);
 
-    extern fn trace_fn(ctx: *mut uw::_Unwind_Context,
-                       arg: *mut c_void) -> uw::_Unwind_Reason_Code {
+    extern "C" fn trace_fn(
+        ctx: *mut uw::_Unwind_Context,
+        arg: *mut c_void,
+    ) -> uw::_Unwind_Reason_Code {
         let cb = unsafe { &mut *(arg as *mut &mut FnMut(&super::Frame) -> bool) };
         let cx = super::Frame {
             inner: Frame::Raw(ctx),
@@ -136,36 +136,40 @@ mod uw {
     pub enum _Unwind_Context {}
 
     pub type _Unwind_Trace_Fn =
-            extern fn(ctx: *mut _Unwind_Context,
-                      arg: *mut c_void) -> _Unwind_Reason_Code;
+        extern "C" fn(ctx: *mut _Unwind_Context, arg: *mut c_void) -> _Unwind_Reason_Code;
 
-    extern {
+    extern "C" {
         // No native _Unwind_Backtrace on iOS
         #[cfg(not(all(target_os = "ios", target_arch = "arm")))]
-        pub fn _Unwind_Backtrace(trace: _Unwind_Trace_Fn,
-                                 trace_argument: *mut c_void)
-                    -> _Unwind_Reason_Code;
+        pub fn _Unwind_Backtrace(
+            trace: _Unwind_Trace_Fn,
+            trace_argument: *mut c_void,
+        ) -> _Unwind_Reason_Code;
 
         // available since GCC 4.2.0, should be fine for our purpose
-        #[cfg(all(not(all(target_os = "android", target_arch = "arm")),
-                  not(all(target_os = "freebsd", target_arch = "arm")),
-                  not(all(target_os = "linux", target_arch = "arm"))))]
-        pub fn _Unwind_GetIP(ctx: *mut _Unwind_Context)
-                    -> libc::uintptr_t;
+        #[cfg(all(
+            not(all(target_os = "android", target_arch = "arm")),
+            not(all(target_os = "freebsd", target_arch = "arm")),
+            not(all(target_os = "linux", target_arch = "arm"))
+        ))]
+        pub fn _Unwind_GetIP(ctx: *mut _Unwind_Context) -> libc::uintptr_t;
 
-        #[cfg(all(not(target_os = "android"),
-                  not(all(target_os = "freebsd", target_arch = "arm")),
-                  not(all(target_os = "linux", target_arch = "arm"))))]
-        pub fn _Unwind_FindEnclosingFunction(pc: *mut c_void)
-            -> *mut c_void;
+        #[cfg(all(
+            not(target_os = "android"),
+            not(all(target_os = "freebsd", target_arch = "arm")),
+            not(all(target_os = "linux", target_arch = "arm"))
+        ))]
+        pub fn _Unwind_FindEnclosingFunction(pc: *mut c_void) -> *mut c_void;
     }
 
     // On android, the function _Unwind_GetIP is a macro, and this is the
     // expansion of the macro. This is all copy/pasted directly from the
     // header file with the definition of _Unwind_GetIP.
-    #[cfg(any(all(target_os = "android", target_arch = "arm"),
-              all(target_os = "freebsd", target_arch = "arm"),
-              all(target_os = "linux", target_arch = "arm")))]
+    #[cfg(any(
+        all(target_os = "android", target_arch = "arm"),
+        all(target_os = "freebsd", target_arch = "arm"),
+        all(target_os = "linux", target_arch = "arm")
+    ))]
     pub unsafe fn _Unwind_GetIP(ctx: *mut _Unwind_Context) -> libc::uintptr_t {
         #[repr(C)]
         enum _Unwind_VRS_Result {
@@ -192,33 +196,36 @@ mod uw {
         }
 
         type _Unwind_Word = libc::c_uint;
-        extern {
-            fn _Unwind_VRS_Get(ctx: *mut _Unwind_Context,
-                               klass: _Unwind_VRS_RegClass,
-                               word: _Unwind_Word,
-                               repr: _Unwind_VRS_DataRepresentation,
-                               data: *mut c_void)
-                -> _Unwind_VRS_Result;
+        extern "C" {
+            fn _Unwind_VRS_Get(
+                ctx: *mut _Unwind_Context,
+                klass: _Unwind_VRS_RegClass,
+                word: _Unwind_Word,
+                repr: _Unwind_VRS_DataRepresentation,
+                data: *mut c_void,
+            ) -> _Unwind_VRS_Result;
         }
 
         let mut val: _Unwind_Word = 0;
         let ptr = &mut val as *mut _Unwind_Word;
-        let _ = _Unwind_VRS_Get(ctx, _Unwind_VRS_RegClass::_UVRSC_CORE, 15,
-                                _Unwind_VRS_DataRepresentation::_UVRSD_UINT32,
-                                ptr as *mut c_void);
+        let _ = _Unwind_VRS_Get(
+            ctx,
+            _Unwind_VRS_RegClass::_UVRSC_CORE,
+            15,
+            _Unwind_VRS_DataRepresentation::_UVRSD_UINT32,
+            ptr as *mut c_void,
+        );
         (val & !1) as libc::uintptr_t
     }
 
     // This function also doesn't exist on Android or ARM/Linux, so make it
     // a no-op
-    #[cfg(any(target_os = "android",
-              all(target_os = "freebsd", target_arch = "arm"),
-              all(target_os = "linux", target_arch = "arm")))]
-    pub unsafe fn _Unwind_FindEnclosingFunction(pc: *mut c_void)
-        -> *mut c_void
-    {
+    #[cfg(any(
+        target_os = "android",
+        all(target_os = "freebsd", target_arch = "arm"),
+        all(target_os = "linux", target_arch = "arm")
+    ))]
+    pub unsafe fn _Unwind_FindEnclosingFunction(pc: *mut c_void) -> *mut c_void {
         pc
     }
 }
-
-

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -121,7 +121,10 @@ cfg_if::cfg_if! {
                 not(all(target_os = "ios", target_arch = "arm")),
                 feature = "libunwind",
             ),
-            target_env = "sgx",
+            all(
+                target_env = "sgx",
+                target_vendor = "fortanix",
+            ),
         )
     )] {
         mod libunwind;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,10 @@
 #![doc(html_root_url = "https://docs.rs/backtrace")]
 #![deny(missing_docs)]
 #![no_std]
-#![cfg_attr(all(feature = "std", target_env = "sgx", target_vendor = "fortanix"), feature(sgx_platform))]
+#![cfg_attr(
+    all(feature = "std", target_env = "sgx", target_vendor = "fortanix"),
+    feature(sgx_platform)
+)]
 #![allow(bare_trait_objects)] // TODO: remove when updating to 2018 edition
 #![allow(rust_2018_idioms)] // TODO: remove when updating to 2018 edition
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 #![doc(html_root_url = "https://docs.rs/backtrace")]
 #![deny(missing_docs)]
 #![no_std]
-#![cfg_attr(all(feature = "std", target_env = "sgx"), feature(sgx_platform))]
+#![cfg_attr(all(feature = "std", target_env = "sgx", target_vendor = "fortanix"), feature(sgx_platform))]
 #![allow(bare_trait_objects)] // TODO: remove when updating to 2018 edition
 #![allow(rust_2018_idioms)] // TODO: remove when updating to 2018 edition
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -196,7 +196,7 @@ impl BacktraceFrameFmt<'_, '_, '_> {
         // To reduce TCB size in Sgx enclave, we do not want to implement symbol
         // resolution functionality.  Rather, we can print the offset of the
         // address here, which could be later mapped to correct function.
-        #[cfg(all(feature = "std", target_env = "sgx"))]
+        #[cfg(all(feature = "std", target_env = "sgx", target_vendor = "fortanix"))]
         {
             let image_base = std::os::fortanix_sgx::mem::image_base();
             frame_ip = usize::wrapping_sub(frame_ip as usize, image_base as _) as _;

--- a/src/symbolize/libbacktrace.rs
+++ b/src/symbolize/libbacktrace.rs
@@ -1,4 +1,4 @@
-﻿// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2014-2015 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -38,8 +38,8 @@ extern crate backtrace_sys as bt;
 use core::{ptr, slice};
 use libc::{self, c_char, c_int, c_void, uintptr_t};
 
-use crate::symbolize::{ResolveWhat, SymbolName};
 use crate::symbolize::dladdr;
+use crate::symbolize::{ResolveWhat, SymbolName};
 use crate::types::BytesOrWideString;
 
 pub enum Symbol<'a> {
@@ -59,22 +59,22 @@ pub enum Symbol<'a> {
 
 impl Symbol<'_> {
     pub fn name(&self) -> Option<SymbolName> {
-        let symbol = |ptr: *const c_char| {
-            unsafe {
-                if ptr.is_null() {
-                    None
-                } else {
-                    let len = libc::strlen(ptr);
-                    Some(SymbolName::new(slice::from_raw_parts(
-                        ptr as *const u8,
-                        len,
-                    )))
-                }
+        let symbol = |ptr: *const c_char| unsafe {
+            if ptr.is_null() {
+                None
+            } else {
+                let len = libc::strlen(ptr);
+                Some(SymbolName::new(slice::from_raw_parts(
+                    ptr as *const u8,
+                    len,
+                )))
             }
         };
         match *self {
             Symbol::Syminfo { symname, .. } => symbol(symname),
-            Symbol::Pcinfo { function, symname, .. } => {
+            Symbol::Pcinfo {
+                function, symname, ..
+            } => {
                 // If possible prefer the `function` name which comes from
                 // debuginfo and can typically be more accurate for inline
                 // frames for example. If that's not present though fall back to
@@ -85,7 +85,7 @@ impl Symbol<'_> {
                 // isntead of `std::panicking::try::do_call`. It's not really
                 // clear why, but overall the `function` name seems more accurate.
                 if let Some(sym) = symbol(function) {
-                    return Some(sym)
+                    return Some(sym);
                 }
                 symbol(symname)
             }
@@ -401,7 +401,7 @@ unsafe fn init_state() -> *mut bt::backtrace_state {
                     lpExeName: LPSTR,
                     lpdwSize: PDWORD,
                 ) -> BOOL = mem::transmute(ptrQueryFullProcessImageNameA);
-                
+
                 let rc = pfnQueryFullProcessImageNameA(p1, 0, buf.as_mut_ptr(), &mut len);
                 CloseHandle(p1);
 
@@ -422,10 +422,10 @@ unsafe fn init_state() -> *mut bt::backtrace_state {
             unsafe fn load_filename() -> *const libc::c_char {
                 use libc;
                 use core::mem;
-                
+
                 const N: usize = libc::VX_RTP_NAME_LENGTH as usize + 1;
                 static mut BUF: [libc::c_char; N] = [0; N];
-                
+
                 let mut rtp_desc : libc::RTP_DESC = mem::zeroed();
                 if (libc::rtpInfoGet(0, &mut rtp_desc as *mut libc::RTP_DESC) == 0) {
                     BUF.copy_from_slice(&rtp_desc.pathName);


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/rust/pull/57243, all of codes used for Fortanix's SGX target should be `cfg`d together with target vendor check `target_vendor = "fortanix"`. If not, these codes would break all other targets using `target_env = "sgx"`