### PR TITLE
Restore the license symlinks in backtrace-sys.

### DIFF
--- a/crates/backtrace-sys/LICENSE-APACHE
+++ b/crates/backtrace-sys/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/backtrace-sys/LICENSE-MIT
+++ b/crates/backtrace-sys/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT


### PR DESCRIPTION
They were removed in 9bd1da5fc3e2, I suspect just because they had the
wrong path after the directories were reorganized.