### PR TITLE
libbacktrace isn't used on HermitCore

### DIFF
--- a/crates/backtrace-sys/build.rs
+++ b/crates/backtrace-sys/build.rs
@@ -10,6 +10,7 @@ fn main() {
     if target.contains("msvc") || // libbacktrace isn't used on MSVC windows
         target.contains("emscripten") || // no way this will ever compile for emscripten
         target.contains("cloudabi") ||
+        target.contains("hermit") ||
         target.contains("wasm32") ||
         target.contains("fuchsia")
     // fuchsia uses external out-of-process symbolization


### PR DESCRIPTION
Currently, HermitCore doesn't support libbacktrace. => disable it