### PR TITLE
Attempt to backtrace through jit frames on x86_64 Windows

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -15,6 +15,10 @@ cfg_if::cfg_if! {
         pub use self::winapi::HINSTANCE;
         pub use self::winapi::FARPROC;
         pub use self::winapi::LPSECURITY_ATTRIBUTES;
+        #[cfg(target_pointer_width = "64")]
+        pub use self::winapi::PUNWIND_HISTORY_TABLE;
+        #[cfg(target_pointer_width = "64")]
+        pub use self::winapi::PRUNTIME_FUNCTION;
 
         mod winapi {
             pub use winapi::ctypes::*;
@@ -35,6 +39,10 @@ cfg_if::cfg_if! {
         pub type HINSTANCE = *mut c_void;
         pub type FARPROC = *mut c_void;
         pub type LPSECURITY_ATTRIBUTES = *mut c_void;
+        #[cfg(target_pointer_width = "64")]
+        pub type PRUNTIME_FUNCTION = *mut c_void;
+        #[cfg(target_pointer_width = "64")]
+        pub type PUNWIND_HISTORY_TABLE = *mut c_void;
     }
 }
 
@@ -371,6 +379,17 @@ ffi! {
             dwMilliseconds: DWORD,
             bAlertable: BOOL,
         ) -> DWORD;
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+ffi! {
+    extern "system" {
+        pub fn RtlLookupFunctionEntry(
+            ControlPc: DWORD64,
+            ImageBase: PDWORD64,
+            HistoryTable: PUNWIND_HISTORY_TABLE,
+        ) -> PRUNTIME_FUNCTION;
     }
 }
 


### PR DESCRIPTION
This is being developed in conjunction with https://github.com/bytecodealliance/wasmtime/pull/759 and should allow `x86_64-pc-windows-*` to natively backtrace through JIT frames 