### PR TITLE
Define HAVE_KERN_PROC on FreeBSD to fix rust-lang/rust#54434

### DIFF
--- a/crates/backtrace-sys/build.rs
+++ b/crates/backtrace-sys/build.rs
@@ -61,7 +61,7 @@ fn main() {
     File::create(out_dir.join("config.h")).unwrap();
     if target.contains("android") {
         maybe_enable_dl_iterate_phdr_android(&mut build);
-    } else if target.contains("freebsd") {
+    } else if target.contains("dragonfly") || target.contains("freebsd") {
         build.define("HAVE_DL_ITERATE_PHDR", "1");
         build.define("HAVE_KERN_PROC", "1");
     } else if target.contains("netbsd") {

--- a/crates/backtrace-sys/build.rs
+++ b/crates/backtrace-sys/build.rs
@@ -61,6 +61,12 @@ fn main() {
     File::create(out_dir.join("config.h")).unwrap();
     if target.contains("android") {
         maybe_enable_dl_iterate_phdr_android(&mut build);
+    } else if target.contains("freebsd") {
+        build.define("HAVE_DL_ITERATE_PHDR", "1");
+        build.define("HAVE_KERN_PROC", "1");
+    } else if target.contains("netbsd") {
+        build.define("HAVE_DL_ITERATE_PHDR", "1");
+        build.define("HAVE_KERN_PROC_ARGS", "1");
     } else if !target.contains("apple-ios")
         && !target.contains("solaris")
         && !target.contains("redox")


### PR DESCRIPTION
Together with [1] this fixes rust-lang/rust#54434. For the same reason optimistically define HAVE_KERN_PROC_ARGS on NetBSD (untested by me though).

To have any effect this requires [1,2].

[1] https://github.com/ianlancetaylor/libbacktrace/commit/0f06cda953cc4e26f38751c5b9f15ae8dfa5ff2d
[2] https://github.com/rust-lang-nursery/libbacktrace/pull/1

