### PR TITLE
Build libbacktrace with mmapio.c instead of read.c

### DIFF
--- a/crates/backtrace-sys/build.rs
+++ b/crates/backtrace-sys/build.rs
@@ -31,9 +31,16 @@ fn main() {
         .file("src/libbacktrace/dwarf.c")
         .file("src/libbacktrace/fileline.c")
         .file("src/libbacktrace/posix.c")
-        .file("src/libbacktrace/read.c")
         .file("src/libbacktrace/sort.c")
         .file("src/libbacktrace/state.c");
+
+    // `mmap` does not exist on Windows, so we use
+    // the less efficient `read`-based code.
+    if target.contains("windows") {
+        build.file("src/libbacktrace/read.c");
+    } else {
+        build.file("src/libbacktrace/mmapio.c");
+    }
 
     // No need to have any symbols reexported form shared objects
     build.flag("-fvisibility=hidden");


### PR DESCRIPTION
Fixes #289

`mmap` should be available on all platforms we support, so we can use
`libbacktrace`'s more efficient mmap-based code.