### PR TITLE
Support line-tables-only when using libbacktrace

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,7 @@ jobs:
     - run: cargo test --features libbacktrace --manifest-path crates/without_debuginfo/Cargo.toml
     - run: cargo test --features "libbacktrace coresymbolication" --manifest-path crates/without_debuginfo/Cargo.toml
     - run: cargo test --features "libbacktrace gimli-symbolize" --manifest-path crates/without_debuginfo/Cargo.toml
+    - run: cargo test --manifest-path crates/line-tables-only/Cargo.toml
 
   windows_arm64:
     name: Windows AArch64

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [workspace]
 members = ['crates/cpp_smoke_test']
-exclude = ['crates/without_debuginfo', 'crates/macos_frames_test']
+exclude = ['crates/without_debuginfo', 'crates/macos_frames_test', 'crates/line-tables-only']
 
 [dependencies]
 cfg-if = "0.1.10"

--- a/crates/line-tables-only/Cargo.toml
+++ b/crates/line-tables-only/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "line-tables-only"
+version = "0.1.0"
+edition = "2018"
+
+[build-dependencies]
+cc = "1.0"
+
+[dependencies]
+libc = { version = "0.2", default-features = false }
+
+[dependencies.backtrace]
+path = "../.."
+features = [
+  'libunwind',
+  'std',
+]
+
+[features]
+libbacktrace = ['backtrace/libbacktrace']

--- a/crates/line-tables-only/build.rs
+++ b/crates/line-tables-only/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    println!("cargo:rerun-if-changed=src/callback.c");
+
+    cc::Build::new()
+        .opt_level(0)
+        .debug(false)
+        .flag("-g1")
+        .file("src/callback.c")
+        .compile("libcallback.a");
+}

--- a/crates/line-tables-only/src/callback.c
+++ b/crates/line-tables-only/src/callback.c
@@ -1,0 +1,14 @@
+
+typedef void (*callback) (void *data);
+
+void baz(callback cb, void *data) {
+  cb(data);
+}
+
+void bar(callback cb, void *data) {
+  baz(cb, data);
+}
+
+void foo(callback cb, void *data) {
+  bar(cb, data);
+}

--- a/crates/line-tables-only/src/lib.rs
+++ b/crates/line-tables-only/src/lib.rs
@@ -1,0 +1,57 @@
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use backtrace::Backtrace;
+    use libc::c_void;
+
+    pub type Callback = extern "C" fn(data: *mut c_void);
+
+    extern "C" {
+        fn foo(cb: Callback, data: *mut c_void);
+    }
+
+    extern "C" fn store_backtrace(data: *mut c_void) {
+        let bt = backtrace::Backtrace::new();
+        unsafe { *(data as *mut Option<Backtrace>) = Some(bt) };
+    }
+
+    fn assert_contains(backtrace: &Backtrace,
+                       expected_name: &str,
+                       expected_file: &str,
+                       expected_line: u32) {
+
+        let expected_file = Path::new(expected_file);
+
+        for frame in backtrace.frames() {
+            for symbol in frame.symbols() {
+                if let Some(name) = symbol.name() {
+                    if name.as_bytes() == expected_name.as_bytes() {
+                        assert_eq!(symbol.filename(), Some(expected_file));
+                        assert_eq!(symbol.lineno(), Some(expected_line));
+                        return;
+                    }
+                }
+            }
+        }
+
+        panic!("symbol {:?} not found in backtrace: {:?}", expected_name, backtrace);
+    }
+
+    /// Verifies that when debug info includes only lines tables the generated
+    /// backtrace is still generated successfully. The test exercises behaviour
+    /// that failed previously when compiling with clang -g1.
+    ///
+    /// The test case uses C rather than rust, since at that time when it was
+    /// written the debug info generated at level 1 in rustc was essentially
+    /// the same as at level 2.
+    #[test]
+    #[cfg_attr(windows, ignore)]
+    fn backtrace_works_with_line_tables_only() {
+        let mut backtrace: Option<Backtrace> = None;
+        unsafe { foo(store_backtrace, &mut backtrace as *mut _ as *mut c_void) };
+        let backtrace = backtrace.expect("backtrace");
+        assert_contains(&backtrace, "foo", "src/callback.c", 13);
+        assert_contains(&backtrace, "bar", "src/callback.c", 9);
+        assert_contains(&backtrace, "baz", "src/callback.c", 5);
+    }
+}

--- a/src/symbolize/libbacktrace.rs
+++ b/src/symbolize/libbacktrace.rs
@@ -111,6 +111,9 @@ impl Symbol<'_> {
             Symbol::Syminfo { .. } => None,
             Symbol::Pcinfo { filename, .. } => {
                 let ptr = filename as *const u8;
+                if ptr.is_null() {
+                    return None;
+                }
                 unsafe {
                     let len = libc::strlen(filename);
                     Some(slice::from_raw_parts(ptr, len))
@@ -220,9 +223,6 @@ extern "C" fn pcinfo_cb(
     lineno: c_int,
     function: *const c_char,
 ) -> c_int {
-    if filename.is_null() || function.is_null() {
-        return -1;
-    }
     let mut bomb = crate::Bomb { enabled: true };
 
     unsafe {


### PR DESCRIPTION
Previously when `backtrace_pcinfo` succeeded, but failed to obtain a
filename or a function name, the line number would be ignored. Instead,
when successful combine all available information.

For example, when using clang `-g1` or `-gline-tables-only` before:

```
   1: baz
   2: bar
   3: foo
```

and after:

```
   1: baz
             at src/callback.c:5
   2: bar
             at src/callback.c:9
   3: foo
             at src/callback.c:13
```

Note that the difference is probably not observable on gcc which includes the
relevant debug info on level 1, nor in rustc where the differences between
debug levels 1 and 2 are currently rather limited.