### PR TITLE
Add reading of general purpose registers.

### DIFF
--- a/src/backtrace/dbghelp.rs
+++ b/src/backtrace/dbghelp.rs
@@ -46,6 +46,10 @@ impl Frame {
         self.ip()
     }
 
+    pub fn gr(&self, index: u32) -> Option<usize> {
+        None
+    }
+
     fn addr_pc(&self) -> &ADDRESS64 {
         match self {
             Frame::New(new) => &new.AddrPC,

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -101,6 +101,14 @@ impl Frame {
     pub fn symbol_address(&self) -> *mut c_void {
         self.inner.symbol_address()
     }
+
+    /// Returns the register value at this frame.
+    ///
+    /// The general purpose register value may not be available. The register
+    /// index differs between platforms.
+    pub fn gr(&self, index: u32) -> Option<usize> {
+        self.inner.gr(index)
+    }
 }
 
 impl fmt::Debug for Frame {

--- a/src/backtrace/noop.rs
+++ b/src/backtrace/noop.rs
@@ -17,4 +17,8 @@ impl Frame {
     pub fn symbol_address(&self) -> *mut c_void {
         0 as *mut _
     }
+
+    pub fn gr(&self, index: u32) -> Option<usize> {
+        None
+    }
 }

--- a/src/backtrace/unix_backtrace.rs
+++ b/src/backtrace/unix_backtrace.rs
@@ -32,6 +32,9 @@ impl Frame {
     pub fn symbol_address(&self) -> *mut c_void {
         self.ip()
     }
+    pub fn gr(&self, index: u32) -> Option<usize> {
+        None
+    }
 }
 
 extern "C" {


### PR DESCRIPTION
This is alternative proposal for #291 or #288. The difference is that the registers content only accessible during `trace()` function. This means that all responsibility of saving registers values falls on the caller.