### PR TITLE
Don't look for old RUSTC_DEBUGINFO vars

### DIFF
--- a/crates/backtrace-sys/build.rs
+++ b/crates/backtrace-sys/build.rs
@@ -89,14 +89,6 @@ fn main() {
     build.define("_GNU_SOURCE", "1");
     build.define("_LARGE_FILES", "1");
 
-    // When we're built as part of the Rust compiler, this is used to enable
-    // debug information in libbacktrace itself.
-    if cfg!(feature = "rustc-dep-of-std") {
-        let any_debug = env::var("RUSTC_DEBUGINFO").unwrap_or_default() == "true"
-            || env::var("RUSTC_DEBUGINFO_LINES").unwrap_or_default() == "true";
-        build.debug(any_debug);
-    }
-
     let syms = [
         "backtrace_full",
         "backtrace_dwarf_add",


### PR DESCRIPTION
This was causing libbacktrace to be built without debuginfo when I had debuginfo enabled in the rust build.

As far as I can tell, these aren't used anymore; they [don't appear](https://github.com/rust-lang/rust/search?q=RUSTC_DEBUGINFO&unscoped_q=RUSTC_DEBUGINFO&type=Code) in rust-lang/rust. The only var that remains in bootstrap is `RUSTC_DEBUGINFO_MAP`.

Instead, using the `DEBUG` environment variable like normal crates do appears to be correct, so no special handling is needed anymore. I verified this works on a local rustc build.