### PR TITLE
WIP: Switch from `goblin` to `object`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,13 @@ cpp_demangle = { default-features = false, version = "0.2.3", optional = true }
 
 # Optional dependencies enabled through the `gimli-symbolize` feature
 addr2line = { version = "0.11.0", optional = true, default-features = false, features = ['std'] }
-goblin = { version = "0.2", optional = true, default-features = false, features = ['elf32', 'elf64', 'mach32', 'mach64', 'pe32', 'pe64', 'std'] }
+
+[dependencies.object]
+git = 'https://github.com/philipc/object'
+branch = 'symbol-table'
+optional = true
+default-features = false
+features = ['read_core', 'elf', 'macho', 'pe']
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.3", optional = true }
@@ -95,7 +101,7 @@ kernel32 = []
 libbacktrace = ["backtrace-sys/backtrace-sys"]
 dladdr = []
 coresymbolication = []
-gimli-symbolize = ["addr2line", "goblin"]
+gimli-symbolize = ["addr2line", "object"]
 
 #=======================================
 # Methods of serialization

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,7 @@ cpp_demangle = { default-features = false, version = "0.2.3", optional = true }
 addr2line = { version = "0.11.0", optional = true, default-features = false, features = ['std'] }
 
 [dependencies.object]
-git = 'https://github.com/philipc/object'
-branch = 'symbol-table'
+git = 'https://github.com/gimli-rs/object'
 optional = true
 default-features = false
 features = ['read_core', 'elf', 'macho', 'pe']


### PR DESCRIPTION
This is a PR using @philipc's [work](https://github.com/gimli-rs/object/issues/215#issuecomment-622917687) to switch the `goblin` dependency of the `gimli-symbolize` feature to the `object` crate instead. I explained some rationale for this [here](https://github.com/gimli-rs/object/issues/215#issue-604046969) but the general idea is that we want a lightweight dependency for parsing object files and `goblin` is a bit heavyweight with its custom derive.

I mostly just wanted to open this up early-ish to verify it works across all platforms.