### PR TITLE
Update `addr2line` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rustc-serialize = { version = "0.3", optional = true }
 cpp_demangle = { default-features = false, version = "0.2.3", optional = true }
 
 # Optional dependencies enabled through the `gimli-symbolize` feature
-addr2line = { version = "0.11.0", optional = true, default-features = false, features = ['std'] }
+addr2line = { version = "0.12.0", optional = true, default-features = false }
 
 [dependencies.object]
 version = "0.19"


### PR DESCRIPTION
Prunes out the `gimli-symbolize` dependency tree to just 3 crates!