### PR TITLE
Switch to `gimli-symbolize` by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,8 @@ jobs:
     - run: cargo build
     - run: cargo test
     - run: cargo test --features "gimli-symbolize"
+    - run: cargo test --features "libbacktrace"
+    - run: cargo test --features "libbacktrace gimli-symbolize"
     - run: cargo test --features "serialize-rustc"
     - run: cargo test --features "serialize-serde"
     - run: cargo test --features "verify-winapi"
@@ -66,6 +68,7 @@ jobs:
     - run: cargo test --no-default-features
     - run: cargo test --no-default-features --features "libbacktrace"
     - run: cargo test --no-default-features --features "gimli-symbolize"
+    - run: cargo test --no-default-features --features "gimli-symbolize libbacktrace"
     - run: cargo test --no-default-features --features "libbacktrace std"
     - run: cargo test --no-default-features --features "gimli-symbolize std"
     - run: cargo test --no-default-features --features "std"
@@ -182,5 +185,5 @@ jobs:
       with:
         submodules: true
     - name: Install Rust
-      run: rustup update 1.32.0 && rustup default 1.32.0
+      run: rustup update 1.40.0 && rustup default 1.40.0
     - run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ features = ['read_core', 'elf', 'macho', 'pe']
 winapi = { version = "0.3.3", optional = true }
 
 [features]
-# By default libstd support and libbacktrace is used to symbolize addresses.
-default = ["std", "libbacktrace"]
+# By default libstd support and gimli-symbolize is used to symbolize addresses.
+default = ["std", "gimli-symbolize"]
 
 # Include std support. This enables types like `Backtrace`.
 std = []
@@ -58,16 +58,17 @@ std = []
 #=======================================
 # Methods of resolving symbols
 #
-# - libbacktrace: this feature activates the `backtrace-sys` dependency,
-#   building the libbacktrace library found in gcc repos. This is the historical
-#   default for the `backtrace` crate.
 # - gimli-symbolize: use the `gimli-rs/addr2line` crate to symbolicate
 #   addresses into file, line, and name using DWARF debug information.
+# - libbacktrace: this feature activates the `backtrace-sys` dependency,
+#   building the libbacktrace library found in gcc repos.
 #
 # Note that MSVC unconditionally uses the dbghelp library to symbolize and won't
-# be affected by feature selection here.
-libbacktrace = ["backtrace-sys/backtrace-sys"]
+# be affected by feature selection here. Also note that it's highly unlikely you
+# want to configure this. If you're having trouble getting backtraces it's
+# likely best to open an issue.
 gimli-symbolize = ["addr2line", "object", "std"]
+libbacktrace = ["backtrace-sys/backtrace-sys"]
 
 #=======================================
 # Methods of serialization

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -282,7 +282,6 @@ cfg_if::cfg_if! {
         use self::elf::Object;
 
         fn native_libraries() -> Vec<Library> {
-            wut();
             let mut ret = Vec::new();
             unsafe {
                 libc::dl_iterate_phdr(Some(callback), &mut ret as *mut _ as *mut _);

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -463,6 +463,7 @@ cfg_if::cfg_if! {
         unsafe fn clear_symbol_cache_imp() {}
     } else if #[cfg(all(
         feature = "gimli-symbolize",
+        any(unix, windows),
         not(target_os = "emscripten"),
     ))] {
         mod gimli;


### PR DESCRIPTION
This commit switches this crate to using `gimli` by default for parsing
DWARF debug information. This is a long time coming and brings a number
of benefits:

* Primarily, Rust is safe. The libbacktrace library has been plagued
  with segfaults ever since we first started using it. Gimli, however,
  is almost entirely safe code. This should make us much more resilient
  in the face of buggy debuginfo.

* Secondarily, it means this library no longer needs a C compiler. Being
  an all-Rust crate generally makes it much easier to cross-compile,
  port, etc.

* Finally, this paves the road for future improvements such as
  split-debuginfo support by default. The libbacktrace library hasn't
  really changed since we started using it years ago, and this gives us
  more control over what's used and how now.

Closes #189