### PR TITLE
sys: Split dep-of-std and symbol prefix features

### DIFF
--- a/crates/backtrace-sys/Cargo.toml
+++ b/crates/backtrace-sys/Cargo.toml
@@ -24,4 +24,8 @@ default = ["backtrace-sys"]
 
 # Without this feature, this crate does nothing.
 backtrace-sys = []
-rustc-dep-of-std = ['core', 'compiler_builtins']
+# Compile backtrace-sys for libstd
+rustc-dep-of-std = ['core', 'compiler_builtins', 'rustc-dep-of-std-prefix']
+# Change the prefix of the embedded libbacktrace symbols to something unique to
+# libstd, to avoid symbol conflicts between the sysroot and normal crates.
+rustc-dep-of-std-prefix = []

--- a/crates/backtrace-sys/build.rs
+++ b/crates/backtrace-sys/build.rs
@@ -123,7 +123,7 @@ fn main() {
         "macho_file_to_host_u32",
         "macho_file_to_host_u16",
     ];
-    let prefix = if cfg!(feature = "rustc-dep-of-std") {
+    let prefix = if cfg!(feature = "rustc-dep-of-std-prefix") {
         println!("cargo:rustc-cfg=rdos");
         "__rdos_"
     } else {


### PR DESCRIPTION
When building a libstd port out-of-tree using [xargo's staged build system](https://github.com/japaric/xargo/#multi-stage-builds), libstd dependencies are allowed to rely on the presence of libcore, compiler-builtins, etc... in the sysroot. Such builds will thus want to remove the `rustc-dep-of-std` feature from libstd dependencies. Doing so for backtrace-sys, however, risks causing duplicate symbols between the sysroot and normal libraries. This is because backtrace-sys links in the libbacktrace library, and has some special logic associated with the `rustc-dep-of-std` feature to rename the symbols.

In order to better support such libstd crates, this commit splits the symbol renaming logic into its own feature, and makes that feature a dependency of rustc-dep-of-std.