### PR TITLE
Handle compressed debug sections in ELF files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,10 @@ jobs:
     - run: cargo test --features gimli-symbolize --manifest-path crates/without_debuginfo/Cargo.toml
     - run: cargo test --manifest-path crates/line-tables-only/Cargo.toml --features libbacktrace
     - run: cargo test --manifest-path crates/line-tables-only/Cargo.toml --features gimli-symbolize
+    - run: RUSTFLAGS="-C link-arg=-Wl,--compress-debug-sections=zlib-gabi" cargo test --features gimli-symbolize
+      if: contains(matrix.os, 'ubuntu')
+    - run: RUSTFLAGS="-C link-arg=-Wl,--compress-debug-sections=zlib-gnu" cargo test --features gimli-symbolize
+      if: contains(matrix.os, 'ubuntu')
 
   windows_arm64:
     name: Windows AArch64

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,12 @@ compiler_builtins = { version = '0.1.2', optional = true }
 # Optional dependencies enabled through the `gimli-symbolize` feature, do not
 # use these features directly.
 addr2line = { version = "0.12.0", optional = true, default-features = false }
+miniz_oxide = { version = "0.3.7", optional = true }
 [dependencies.object]
-version = "0.19"
+git = "https://github.com/gimli-rs/object.git"
 optional = true
 default-features = false
-features = ['read_core', 'elf', 'macho', 'pe']
+features = ['read_core', 'elf', 'macho', 'pe', 'unaligned']
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.3", optional = true }
@@ -71,7 +72,7 @@ std = []
 # be affected by feature selection here. Also note that it's highly unlikely you
 # want to configure this. If you're having trouble getting backtraces it's
 # likely best to open an issue.
-gimli-symbolize = ["addr2line", "object", "std"]
+gimli-symbolize = ["addr2line", "miniz_oxide", "object", "std"]
 libbacktrace = ["backtrace-sys/backtrace-sys"]
 
 #=======================================

--- a/src/symbolize/gimli/coff.rs
+++ b/src/symbolize/gimli/coff.rs
@@ -1,4 +1,4 @@
-use super::{Mapping, Path, Vec};
+use super::{Mapping, Path, Stash, Vec};
 use object::pe::{ImageDosHeader, ImageSymbol};
 use object::read::pe::{ImageNtHeaders, ImageOptionalHeader, SectionTable};
 use object::read::StringTable;
@@ -13,8 +13,9 @@ use std::convert::TryFrom;
 impl Mapping {
     pub fn new(path: &Path) -> Option<Mapping> {
         let map = super::mmap(path)?;
-        let cx = super::cx(Object::parse(&map)?)?;
-        Some(mk!(Mapping { map, cx }))
+        let stash = Stash::new();
+        let cx = super::cx(&stash, Object::parse(&map)?)?;
+        Some(mk!(Mapping { map, cx, stash }))
     }
 }
 
@@ -66,7 +67,7 @@ impl<'a> Object<'a> {
         })
     }
 
-    pub fn section(&self, name: &str) -> Option<&'a [u8]> {
+    pub fn section(&self, _: &Stash, name: &str) -> Option<&'a [u8]> {
         Some(
             self.sections
                 .section_by_name(self.strings, name.as_bytes())?

--- a/src/symbolize/gimli/elf.rs
+++ b/src/symbolize/gimli/elf.rs
@@ -1,7 +1,9 @@
-use super::{Mapping, Path, Vec};
-use object::read::elf::{FileHeader, SectionHeader, SectionTable, Sym};
+use super::{Mapping, Path, Stash, Vec};
+use object::elf::{ELFCOMPRESS_ZLIB, SHF_COMPRESSED};
+use object::read::elf::{CompressionHeader, FileHeader, SectionHeader, SectionTable, Sym};
 use object::read::StringTable;
-use object::{Bytes, NativeEndian};
+use object::{BigEndian, Bytes, NativeEndian};
+use std::io::Cursor;
 
 #[cfg(target_pointer_width = "32")]
 type Elf = object::elf::FileHeader32<NativeEndian>;
@@ -11,8 +13,9 @@ type Elf = object::elf::FileHeader64<NativeEndian>;
 impl Mapping {
     pub fn new(path: &Path) -> Option<Mapping> {
         let map = super::mmap(path)?;
-        let cx = super::cx(Object::parse(&map)?)?;
-        Some(mk!(Mapping { map, cx }))
+        let stash = Stash::new();
+        let cx = super::cx(&stash, Object::parse(&map)?)?;
+        Some(mk!(Mapping { map, cx, stash }))
     }
 }
 
@@ -87,15 +90,53 @@ impl<'a> Object<'a> {
         })
     }
 
-    pub fn section(&self, name: &str) -> Option<&'a [u8]> {
-        Some(
-            self.sections
-                .section_by_name(self.endian, name.as_bytes())?
-                .1
-                .data(self.endian, self.data)
-                .ok()?
-                .0,
-        )
+    pub fn section(&self, stash: &'a Stash, name: &str) -> Option<&'a [u8]> {
+        if let Some(section) = self.section_header(name) {
+            let mut data = section.data(self.endian, self.data).ok()?;
+
+            // Check for DWARF-standard (gABI) compression, i.e., as generated
+            // by ld's `--compress-debug-sections=zlib-gabi` flag.
+            let flags: u64 = section.sh_flags(self.endian).into();
+            if (flags & u64::from(SHF_COMPRESSED)) == 0 {
+                // Not compressed.
+                return Some(data.0);
+            }
+
+            let header = data.read::<<Elf as FileHeader>::CompressionHeader>().ok()?;
+            if header.ch_type(self.endian) != ELFCOMPRESS_ZLIB {
+                // Zlib compression is the only known type.
+                return None;
+            }
+            let size = header.ch_size(self.endian) as usize;
+            let buf = stash.allocate(size);
+            decompress_zlib(data.0, buf)?;
+            return Some(buf);
+        }
+
+        // Check for the nonstandard GNU compression format, i.e., as generated
+        // by ld's `--compress-debug-sections=zlib-gnu` flag.
+        if !name.starts_with(".debug_") {
+            return None;
+        }
+        let zdebug_name = format!(".zdebug_{}", &name[7..]);
+        if let Some(section) = self.section_header(&zdebug_name) {
+            let mut data = section.data(self.endian, self.data).ok()?;
+            if data.read_bytes(8).ok()?.0 != b"ZLIB\0\0\0\0" {
+                return None;
+            }
+            let size = data.read::<object::U32Bytes<_>>().ok()?.get(BigEndian) as usize;
+            let buf = stash.allocate(size);
+            decompress_zlib(data.0, buf)?;
+            return Some(buf);
+        }
+
+        None
+    }
+
+    fn section_header(&self, name: &str) -> Option<&<Elf as FileHeader>::SectionHeader> {
+        self.sections
+            .section_by_name(self.endian, name.as_bytes())
+            .map(|(_index, section)| section)
     }
 
     pub fn search_symtab<'b>(&'b self, addr: u64) -> Option<&'b [u8]> {
@@ -110,5 +151,25 @@ impl<'a> Object<'a> {
         } else {
             None
         }
+    }
+}
+
+fn decompress_zlib(input: &[u8], output: &mut [u8]) -> Option<()> {
+    use miniz_oxide::inflate::core::inflate_flags::{
+        TINFL_FLAG_PARSE_ZLIB_HEADER, TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF,
+    };
+    use miniz_oxide::inflate::core::{decompress, DecompressorOxide};
+    use miniz_oxide::inflate::TINFLStatus;
+
+    let (status, in_read, out_read) = decompress(
+        &mut DecompressorOxide::new(),
+        input,
+        &mut Cursor::new(output),
+        TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF | TINFL_FLAG_PARSE_ZLIB_HEADER,
+    );
+    if status == TINFLStatus::Done && in_read == input.len() && out_read == output.len() {
+        Some(())
+    } else {
+        None
     }
 }

--- a/src/symbolize/gimli/stash.rs
+++ b/src/symbolize/gimli/stash.rs
@@ -1,0 +1,28 @@
+use std::cell::UnsafeCell;
+use std::vec::Vec;
+
+/// A simple arena allocator for byte buffers.
+pub struct Stash {
+    buffers: UnsafeCell<Vec<Vec<u8>>>,
+}
+
+impl Stash {
+    pub fn new() -> Stash {
+        Stash {
+            buffers: UnsafeCell::new(Vec::new()),
+        }
+    }
+
+    /// Allocates a buffer of the specified size and returns a mutable reference
+    /// to it.
+    pub fn allocate(&self, size: usize) -> &mut [u8] {
+        // SAFETY: this is the only function that ever constructs a mutable
+        // reference to `self.buffers`.
+        let buffers = unsafe { &mut *self.buffers.get() };
+        let i = buffers.len();
+        buffers.push(vec![0; size]);
+        // SAFETY: we never remove elements from `self.buffers`, so a reference
+        // to the data inside any buffer will live as long as `self` does.
+        &mut buffers[i]
+    }
+}


### PR DESCRIPTION
@alexcrichton this will need to wait for the `unaligned` feature to land in an actual release of the object crate, but otherwise it's ready to go from my perspective. Let me know what you think! Don't think there's a good way around the `flate2` dependency (I guess we could depend on mini_oxide directly?). Do you think that'll be a showstopper for inclusion in libstd?

----

ELF files allow debug info sections to be compressed. The libbacktrace
backed supported these compressed sections, but the Gimli backend did
not. This commit adds that support to the Gimli backend.

In my tests these debug info sections do not obey the alignment
requirements that the object crate expects for the gABI compression
header (nor can I find a source documenting any alignment requirements),
so this commit additionally enables the "unaligned" feature in the
upcoming version of the object crate.

There is a bit of unsafe to ensure the lifetime of the decompressed
sections matches the lifetime of the mmap'd file. I don't think there is
a way around this unsafe code, unless we are willing to ditch Gimli's
EndianSlice for an (apparently slower) EndianReader backed by a
Cow<[u8]>.

Fix #342.