### PR TITLE
Add the current executables directory to the search path

### DIFF
--- a/src/dbghelp.rs
+++ b/src/dbghelp.rs
@@ -73,6 +73,12 @@ mod dbghelp {
             pdwDisplacement: PDWORD,
             Line: PIMAGEHLP_LINEW64,
         ) -> BOOL;
+        pub fn SymGetSearchPathW(
+            hProcess: HANDLE,
+            SearchPath: PWSTR,
+            SearchPathLength: DWORD,
+        ) -> BOOL;
+        pub fn SymSetSearchPathW(hProcess: HANDLE, SearchPath: PCWSTR) -> BOOL;
     }
 
     pub fn assert_equal_types<T>(a: T, _b: T) -> T {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -377,6 +377,7 @@ ffi! {
         pub fn RtlCaptureContext(ContextRecord: PCONTEXT) -> ();
         pub fn LoadLibraryA(a: *const i8) -> HMODULE;
         pub fn GetProcAddress(h: HMODULE, name: *const i8) -> FARPROC;
+        pub fn GetModuleFileNameW(h: HMODULE, lpFilename: PWSTR, nSize: DWORD) -> DWORD;
         pub fn GetModuleHandleA(name: *const i8) -> HMODULE;
         pub fn OpenProcess(
             dwDesiredAccess: DWORD,


### PR DESCRIPTION
This change configures the dbghelp.dll search path so that it includes the directory of the running executable.

The default search path is the working directory, followed by the contents on the _NT_SYMBOL_PATH and _NT_ALTERNATE_SYMBOL_PATH environment variables. (https://docs.microsoft.com/en-us/windows/win32/api/dbghelp/nf-dbghelp-syminitialize). However it is common to deploy windows executables with the .exe and .pdb file side-by-side. This works fine as long as these files are in the working directory, but symbol resolution will fail when run from any other directory.
