### PR TITLE
Add test for backtracing after stack overflow.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        thing: [stable, beta, nightly, macos, windows-msvc64, windows-msvc32, windows-gnu64, windows-gnu32]
+        thing: [stable, beta, nightly, macos, macos-nightly, windows-msvc64, windows-msvc32, windows-gnu64, windows-gnu32]
         include:
           - thing: stable
             os: ubuntu-latest
@@ -28,6 +28,9 @@ jobs:
           - thing: macos
             os: macos-latest
             rust: stable
+          - thing: macos-nightly
+            os: macos-latest
+            rust: nightly
           # Note that these are on nightly due to rust-lang/rust#63700 not being
           # on stable yet
           - thing: windows-msvc64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        thing: [stable, beta, nightly, macos, macos-nightly, windows-msvc64, windows-msvc32, windows-gnu64, windows-gnu32]
+        thing: [stable, beta, nightly, macos-stable, macos-beta, macos-nightly, windows-msvc64, windows-msvc32, windows-gnu64, windows-gnu32]
         include:
           - thing: stable
             os: ubuntu-latest
@@ -25,9 +25,12 @@ jobs:
           - thing: nightly
             os: ubuntu-latest
             rust: nightly
-          - thing: macos
+          - thing: macos-stable
             os: macos-latest
             rust: stable
+          - thing: macos-beta
+            os: macos-latest
+            rust: beta
           - thing: macos-nightly
             os: macos-latest
             rust: nightly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,7 @@ jobs:
     - run: cargo build --manifest-path crates/backtrace-sys/Cargo.toml
     - run: cargo build
     - run: cargo test
+    - run: cargo test --release
     - run: cargo test --features "gimli-symbolize"
     - run: cargo test --features "libbacktrace"
     - run: cargo test --features "libbacktrace gimli-symbolize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,3 +144,9 @@ edition = '2018'
 name = "concurrent-panics"
 required-features = ["std"]
 harness = false
+
+[[test]]
+name = "stack-overflow"
+required-features = ["std"]
+edition = '2018'
+harness = false

--- a/tests/accuracy/main.rs
+++ b/tests/accuracy/main.rs
@@ -15,6 +15,8 @@ macro_rules! check {
 type Pos = (&'static str, u32);
 
 #[test]
+// FIXME: This test depends on debuginfo and runs only with debug builds.
+#[cfg(debug_assertions)]
 fn doit() {
     if
     // Skip musl which is by default statically linked and doesn't support

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -232,6 +232,8 @@ fn is_serde() {
 }
 
 #[test]
+// FIXME: This test depends on debuginfo and runs only with debug builds.
+#[cfg(debug_assertions)]
 fn sp_smoke_test() {
     let mut refs = vec![];
     recursive_stack_references(&mut refs);

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -5,6 +5,8 @@ static LIBBACKTRACE: bool = cfg!(feature = "libbacktrace") && !cfg!(target_os = 
 static GIMLI_SYMBOLIZE: bool = cfg!(all(feature = "gimli-symbolize", unix, target_os = "linux"));
 
 #[test]
+// FIXME: This test depends on debuginfo and runs only with debug builds.
+#[cfg(debug_assertions)]
 // FIXME: shouldn't ignore this test on i686-msvc, unsure why it's failing
 #[cfg_attr(all(target_arch = "x86", target_env = "msvc"), ignore)]
 #[rustfmt::skip] // we care about line numbers here

--- a/tests/stack-overflow.rs
+++ b/tests/stack-overflow.rs
@@ -1,0 +1,61 @@
+fn main() {
+    test::run();
+}
+
+#[cfg(unix)]
+mod test {
+    use backtrace::Backtrace;
+    use std::{mem, ptr};
+
+    #[inline(never)]
+    fn f(x: i32) -> i32 {
+        if x == 0 || x == 1 {
+            1
+        } else {
+            f(x - 1) + f(x - 2)
+        }
+    }
+
+    pub fn run() {
+        unsafe {
+            // Allocate a large enough sigaltstack.
+            let mut stack_space = vec![0u8; 1048576];
+            let new_stack = libc::stack_t {
+                ss_sp: stack_space.as_mut_ptr() as *mut _,
+                ss_flags: 0,
+                ss_size: 1048576,
+            };
+
+            assert_eq!(libc::sigaltstack(&new_stack, ptr::null_mut()), 0);
+
+            let mut handler: libc::sigaction = mem::zeroed();
+            handler.sa_flags = libc::SA_ONSTACK;
+            handler.sa_sigaction = trap_handler as usize;
+            libc::sigemptyset(&mut handler.sa_mask);
+            assert_eq!(libc::sigaction(libc::SIGSEGV, &handler, ptr::null_mut()), 0);
+
+            // Backtracing from a normal SIGSEGV works
+            //println!("Before invalid write");
+            //ptr::write_volatile(0 as *mut u32, 0);
+            //println!("After invalid write");
+
+            // Backtracing from a stack overflow crashes on macOS
+            panic!("{}", f(0xfffffff));
+        }
+    }
+
+    unsafe extern "C" fn trap_handler(_: libc::c_int) {
+        let backtrace = Backtrace::new_unresolved();
+        assert!(format!("{:?}", backtrace).len() > 0);
+        println!("test result: ok");
+        libc::_exit(0);
+    }
+}
+
+#[cfg(not(unix))]
+mod test {
+    /// Ignore the test on non-Unix platforms.
+    pub fn run() {
+        println!("test result: ok");
+    }
+}

--- a/tests/stack-overflow.rs
+++ b/tests/stack-overflow.rs
@@ -40,11 +40,14 @@ mod test {
             //println!("After invalid write");
 
             // Backtracing from a stack overflow crashes on macOS
-            panic!("{}", f(0xfffffff));
+            println!("Before stack overflow");
+            println!("{}", f(0xfffffff));
+            println!("After stack overflow");
         }
     }
 
     unsafe extern "C" fn trap_handler(_: libc::c_int) {
+        println!("Backtrace begin");
         let backtrace = Backtrace::new_unresolved();
         assert!(format!("{:?}", backtrace).len() > 0);
         println!("test result: ok");


### PR DESCRIPTION
This PR adds a test that triggers https://github.com/rust-lang/backtrace-rs/issues/356 .

For me, currently the added test fails on macOS with SIGSEGV but not Linux:

```
     Running target/release/deps/stack_overflow-8c961da828d1b0c2
Before stack overflow
Backtrace begin
error: test failed, to rerun pass '--test stack-overflow'
```

Interestingly, if the line `println!("Before stack overflow");` is removed then the test works on macOS - looks like there's some randomness here.