### PR TITLE
Use noop symbolizer for target_env = "devkita64"

### DIFF
--- a/crates/backtrace-sys/build.rs
+++ b/crates/backtrace-sys/build.rs
@@ -14,7 +14,8 @@ fn main() {
         target.contains("hermit") ||
         target.contains("wasm32") ||
         target.contains("fuchsia") ||
-        target.contains("uclibc")
+        target.contains("uclibc") ||
+        target.contains("devkita64")
     {
         println!("cargo:rustc-cfg=empty");
         return;

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -467,6 +467,7 @@ cfg_if::cfg_if! {
         not(target_os = "fuchsia"),
         not(target_os = "emscripten"),
         not(target_env = "uclibc"),
+        not(target_env = "devkita64"),
     ))] {
         mod libbacktrace;
         use self::libbacktrace::resolve as resolve_imp;
@@ -476,6 +477,7 @@ cfg_if::cfg_if! {
         feature = "gimli-symbolize",
         any(unix, windows),
         not(target_os = "emscripten"),
+        not(target_env = "devkita64"),
     ))] {
         mod gimli;
         use self::gimli::resolve as resolve_imp;


### PR DESCRIPTION
This is necessary for a WIP Rust target that I can hopefully upstream the rest of relatively soon.

The target (Nintendo Switch homebrew) doesn't have a standard way to distribute debug info, so I haven't implemented a full symbolizer. I had a prototype using <https://github.com/MegatonHammer/linkle>'s DWARF support, but I'd like to think about that some more before baking it into libstd.