### PR TITLE
use noop backends on Miri

### DIFF
--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -121,7 +121,11 @@ impl fmt::Debug for Frame {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(
+    if #[cfg(miri)] {
+        mod noop;
+        use self::noop::trace as trace_imp;
+        pub(crate) use self::noop::Frame as FrameImp;
+    } else if #[cfg(
         any(
             all(
                 unix,

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -456,7 +456,13 @@ pub fn clear_symbol_cache() {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(all(windows, target_env = "msvc", not(target_vendor = "uwp")))] {
+    if #[cfg(miri)] {
+        mod noop;
+        use self::noop::resolve as resolve_imp;
+        use self::noop::Symbol as SymbolImp;
+        #[allow(unused)]
+        unsafe fn clear_symbol_cache_imp() {}
+    } else if #[cfg(all(windows, target_env = "msvc", not(target_vendor = "uwp")))] {
         mod dbghelp;
         use self::dbghelp::resolve as resolve_imp;
         use self::dbghelp::Symbol as SymbolImp;


### PR DESCRIPTION
This is needed to unblock https://github.com/rust-lang/rust/issues/74484. Before the recent backtrace changes, Miri did use the noop backend (not sure whether by unsetting all feature flags or with some special cases somewhere); seems like that got lost in the transition.