### PR TITLE
Don't use gimli symbolizer for UWP targets.

### DIFF
--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -481,6 +481,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(all(
         feature = "gimli-symbolize",
         any(unix, windows),
+        not(target_vendor = "uwp"),
         not(target_os = "emscripten"),
     ))] {
         mod gimli;


### PR DESCRIPTION
The gimli symbolizer relies on forbidden Win32 APIs including Module32FirstW and Module32NextW, which prevents submitting apps that depend on backtrace to the Windows store.