### PR TITLE
Disable libbacktrace on libnx

### DIFF
--- a/crates/backtrace-sys/build.rs
+++ b/crates/backtrace-sys/build.rs
@@ -14,7 +14,8 @@ fn main() {
         target.contains("hermit") ||
         target.contains("wasm32") ||
         target.contains("fuchsia") ||
-        target.contains("uclibc")
+        target.contains("uclibc") ||
+        target.contains("libnx")
     {
         println!("cargo:rustc-cfg=empty");
         return;

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -473,6 +473,7 @@ cfg_if::cfg_if! {
         not(target_os = "fuchsia"),
         not(target_os = "emscripten"),
         not(target_env = "uclibc"),
+        not(target_env = "libnx"),
     ))] {
         mod libbacktrace;
         use self::libbacktrace::resolve as resolve_imp;


### PR DESCRIPTION
This is necessary due to https://github.com/rust-lang/rust/pull/74613.