### PR TITLE
Include source column numbers, where available

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -94,6 +94,7 @@ pub struct BacktraceSymbol {
     addr: Option<usize>,
     filename: Option<PathBuf>,
     lineno: Option<u32>,
+    colno: Option<u32>,
 }
 
 impl Backtrace {
@@ -213,6 +214,7 @@ impl Backtrace {
                         addr: symbol.addr().map(|a| a as usize),
                         filename: symbol.filename().map(|m| m.to_owned()),
                         lineno: symbol.lineno(),
+                        colno: symbol.colno(),
                     });
                 };
                 match frame.frame {
@@ -322,6 +324,16 @@ impl BacktraceSymbol {
     pub fn lineno(&self) -> Option<u32> {
         self.lineno
     }
+
+    /// Same as `Symbol::colno`
+    ///
+    /// # Required features
+    ///
+    /// This function requires the `std` feature of the `backtrace` crate to be
+    /// enabled, and the `std` feature is enabled by default.
+    pub fn colno(&self) -> Option<u32> {
+        self.colno
+    }
 }
 
 impl fmt::Debug for Backtrace {
@@ -383,6 +395,7 @@ impl fmt::Debug for BacktraceSymbol {
             .field("addr", &self.addr())
             .field("filename", &self.filename())
             .field("lineno", &self.lineno())
+            .field("colno", &self.colno())
             .finish()
     }
 }

--- a/src/print.rs
+++ b/src/print.rs
@@ -242,7 +242,12 @@ impl BacktraceFrameFmt<'_, '_, '_> {
         Ok(())
     }
 
-    fn print_fileline(&mut self, file: BytesOrWideString<'_>, line: u32, colno: Option<u32>) -> fmt::Result {
+    fn print_fileline(
+        &mut self,
+        file: BytesOrWideString<'_>,
+        line: u32,
+        colno: Option<u32>,
+    ) -> fmt::Result {
         // Filename/line are printed on lines under the symbol name, so print
         // some appropriate whitespace to sort of right-align ourselves.
         if let PrintFmt::Full = self.fmt.format {

--- a/src/symbolize/dbghelp.rs
+++ b/src/symbolize/dbghelp.rs
@@ -62,6 +62,10 @@ impl Symbol<'_> {
             .map(|slice| unsafe { BytesOrWideString::Wide(&*slice) })
     }
 
+    pub fn colno(&self) -> Option<u32> {
+        None
+    }
+
     pub fn lineno(&self) -> Option<u32> {
         self.line
     }

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -682,4 +682,11 @@ impl Symbol<'_> {
             Symbol::Symtab { .. } => None,
         }
     }
+
+    pub fn colno(&self) -> Option<u32> {
+        match self {
+            Symbol::Frame { location, .. } => location.as_ref()?.column,
+            Symbol::Symtab { .. } => None,
+        }
+    }
 }

--- a/src/symbolize/libbacktrace.rs
+++ b/src/symbolize/libbacktrace.rs
@@ -149,6 +149,10 @@ impl Symbol<'_> {
             Symbol::Pcinfo { lineno, .. } => Some(lineno as u32),
         }
     }
+
+    pub fn colno(&self) -> Option<u32> {
+        None
+    }
 }
 
 extern "C" fn error_cb(_data: *mut c_void, _msg: *const c_char, _errnum: c_int) {

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -219,6 +219,14 @@ impl Symbol {
         self.inner.filename_raw()
     }
 
+    /// Returns the column number for where this symbol is currently executing.
+    ///
+    /// Only gimli currently provides a value here and even then only if `filename`
+    /// returns `Some`, and so it is then consequently subject to similar caveats.
+    pub fn colno(&self) -> Option<u32> {
+        self.inner.colno()
+    }
+
     /// Returns the line number for where this symbol is currently executing.
     ///
     /// This return value is typically `Some` if `filename` returns `Some`, and
@@ -229,8 +237,8 @@ impl Symbol {
 
     /// Returns the file name where this function was defined.
     ///
-    /// This is currently only available when libbacktrace is being used (e.g.
-    /// unix platforms other than OSX) and when a binary is compiled with
+    /// This is currently only available when libbacktrace or gimli is being
+    /// used (e.g. unix platforms other) and when a binary is compiled with
     /// debuginfo. If neither of these conditions is met then this will likely
     /// return `None`.
     ///

--- a/src/symbolize/noop.rs
+++ b/src/symbolize/noop.rs
@@ -32,4 +32,8 @@ impl Symbol<'_> {
     pub fn lineno(&self) -> Option<u32> {
         None
     }
+
+    pub fn colno(&self) -> Option<u32> {
+        None
+    }
 }


### PR DESCRIPTION
It'd be great if backtraces could include source column numbers, in addition to filename/line numbers (where available - currently only gimli).

Closes #257 