### PR TITLE
Feature: module base address added to the Frame

### DIFF
--- a/crates/without_debuginfo/tests/smoke.rs
+++ b/crates/without_debuginfo/tests/smoke.rs
@@ -27,3 +27,18 @@ fn all_frames_have_symbols() {
         assert_eq!(missing_symbols, 0);
     }
 }
+
+#[test]
+fn all_frames_have_module_base_address() {
+    let mut missing_base_addresses = 0;
+    backtrace::trace(|frame| {
+        if frame.module_base_address().is_none() {
+            missing_base_addresses += 1;
+        }
+        true
+    });
+
+    if cfg!(windows) {
+        assert_eq!(missing_base_addresses, 0);
+    }
+}

--- a/src/backtrace/dbghelp.rs
+++ b/src/backtrace/dbghelp.rs
@@ -141,6 +141,8 @@ pub unsafe fn trace(cb: &mut dyn FnMut(&super::Frame) -> bool) {
         }
     }
 
+    let process_handle = GetCurrentProcess();
+
     // Attempt to use `StackWalkEx` if we can, but fall back to `StackWalk64`
     // since it's in theory supported on more systems.
     match (*dbghelp.dbghelp()).StackWalkEx() {
@@ -170,8 +172,7 @@ pub unsafe fn trace(cb: &mut dyn FnMut(&super::Frame) -> bool) {
                 0,
             ) == TRUE
             {
-                frame.inner.base_address =
-                    get_module_base(GetCurrentProcess(), frame.ip() as _) as _;
+                frame.inner.base_address = get_module_base(process_handle, frame.ip() as _) as _;
 
                 if !cb(&frame) {
                     break;
@@ -203,8 +204,7 @@ pub unsafe fn trace(cb: &mut dyn FnMut(&super::Frame) -> bool) {
                 None,
             ) == TRUE
             {
-                frame.inner.base_address =
-                    get_module_base(GetCurrentProcess(), frame.ip() as _) as _;
+                frame.inner.base_address = get_module_base(process_handle, frame.ip() as _) as _;
 
                 if !cb(&frame) {
                     break;

--- a/src/backtrace/dbghelp.rs
+++ b/src/backtrace/dbghelp.rs
@@ -26,9 +26,15 @@ use core::ffi::c_void;
 use core::mem;
 
 #[derive(Clone, Copy)]
-pub enum Frame {
+pub enum StackFrame {
     New(STACKFRAME_EX),
     Old(STACKFRAME64),
+}
+
+#[derive(Clone, Copy)]
+pub struct Frame {
+    pub(crate) stack_frame: StackFrame,
+    base_address: *mut c_void,
 }
 
 // we're just sending around raw pointers and reading them, never interpreting
@@ -49,38 +55,42 @@ impl Frame {
         self.ip()
     }
 
+    pub fn module_base_address(&self) -> Option<*mut c_void> {
+        Some(self.base_address)
+    }
+
     fn addr_pc(&self) -> &ADDRESS64 {
-        match self {
-            Frame::New(new) => &new.AddrPC,
-            Frame::Old(old) => &old.AddrPC,
+        match self.stack_frame {
+            StackFrame::New(ref new) => &new.AddrPC,
+            StackFrame::Old(ref old) => &old.AddrPC,
         }
     }
 
     fn addr_pc_mut(&mut self) -> &mut ADDRESS64 {
-        match self {
-            Frame::New(new) => &mut new.AddrPC,
-            Frame::Old(old) => &mut old.AddrPC,
+        match self.stack_frame {
+            StackFrame::New(ref mut new) => &mut new.AddrPC,
+            StackFrame::Old(ref mut old) => &mut old.AddrPC,
         }
     }
 
     fn addr_frame_mut(&mut self) -> &mut ADDRESS64 {
-        match self {
-            Frame::New(new) => &mut new.AddrFrame,
-            Frame::Old(old) => &mut old.AddrFrame,
+        match self.stack_frame {
+            StackFrame::New(ref mut new) => &mut new.AddrFrame,
+            StackFrame::Old(ref mut old) => &mut old.AddrFrame,
         }
     }
 
     fn addr_stack(&self) -> &ADDRESS64 {
-        match self {
-            Frame::New(new) => &new.AddrStack,
-            Frame::Old(old) => &old.AddrStack,
+        match self.stack_frame {
+            StackFrame::New(ref new) => &new.AddrStack,
+            StackFrame::Old(ref old) => &old.AddrStack,
         }
     }
 
     fn addr_stack_mut(&mut self) -> &mut ADDRESS64 {
-        match self {
-            Frame::New(new) => &mut new.AddrStack,
-            Frame::Old(old) => &mut old.AddrStack,
+        match self.stack_frame {
+            StackFrame::New(ref mut new) => &mut new.AddrStack,
+            StackFrame::Old(ref mut old) => &mut old.AddrStack,
         }
     }
 }
@@ -136,11 +146,14 @@ pub unsafe fn trace(cb: &mut dyn FnMut(&super::Frame) -> bool) {
     match (*dbghelp.dbghelp()).StackWalkEx() {
         Some(StackWalkEx) => {
             let mut frame = super::Frame {
-                inner: Frame::New(mem::zeroed()),
+                inner: Frame {
+                    stack_frame: StackFrame::New(mem::zeroed()),
+                    base_address: 0 as _,
+                },
             };
             let image = init_frame(&mut frame.inner, &context.0);
-            let frame_ptr = match &mut frame.inner {
-                Frame::New(ptr) => ptr as *mut STACKFRAME_EX,
+            let frame_ptr = match &mut frame.inner.stack_frame {
+                StackFrame::New(ptr) => ptr as *mut STACKFRAME_EX,
                 _ => unreachable!(),
             };
 
@@ -157,6 +170,9 @@ pub unsafe fn trace(cb: &mut dyn FnMut(&super::Frame) -> bool) {
                 0,
             ) == TRUE
             {
+                frame.inner.base_address =
+                    get_module_base(GetCurrentProcess(), frame.ip() as _) as _;
+
                 if !cb(&frame) {
                     break;
                 }
@@ -164,11 +180,14 @@ pub unsafe fn trace(cb: &mut dyn FnMut(&super::Frame) -> bool) {
         }
         None => {
             let mut frame = super::Frame {
-                inner: Frame::Old(mem::zeroed()),
+                inner: Frame {
+                    stack_frame: StackFrame::Old(mem::zeroed()),
+                    base_address: 0 as _,
+                },
             };
             let image = init_frame(&mut frame.inner, &context.0);
-            let frame_ptr = match &mut frame.inner {
-                Frame::Old(ptr) => ptr as *mut STACKFRAME64,
+            let frame_ptr = match &mut frame.inner.stack_frame {
+                StackFrame::Old(ptr) => ptr as *mut STACKFRAME64,
                 _ => unreachable!(),
             };
 
@@ -184,6 +203,9 @@ pub unsafe fn trace(cb: &mut dyn FnMut(&super::Frame) -> bool) {
                 None,
             ) == TRUE
             {
+                frame.inner.base_address =
+                    get_module_base(GetCurrentProcess(), frame.ip() as _) as _;
+
                 if !cb(&frame) {
                     break;
                 }

--- a/src/backtrace/libunwind.rs
+++ b/src/backtrace/libunwind.rs
@@ -79,6 +79,10 @@ impl Frame {
             unsafe { uw::_Unwind_FindEnclosingFunction(self.ip()) }
         }
     }
+
+    pub fn module_base_address(&self) -> Option<*mut c_void> {
+        None
+    }
 }
 
 impl Clone for Frame {

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -109,6 +109,11 @@ impl Frame {
     pub fn symbol_address(&self) -> *mut c_void {
         self.inner.symbol_address()
     }
+
+    /// Returns the base address of the module to which the frame belongs.
+    pub fn module_base_address(&self) -> Option<*mut c_void> {
+        self.inner.module_base_address()
+    }
 }
 
 impl fmt::Debug for Frame {
@@ -145,6 +150,7 @@ cfg_if::cfg_if! {
         mod dbghelp;
         use self::dbghelp::trace as trace_imp;
         pub(crate) use self::dbghelp::Frame as FrameImp;
+        pub(crate) use self::dbghelp::StackFrame;
     } else {
         mod noop;
         use self::noop::trace as trace_imp;

--- a/src/backtrace/noop.rs
+++ b/src/backtrace/noop.rs
@@ -21,4 +21,8 @@ impl Frame {
     pub fn symbol_address(&self) -> *mut c_void {
         0 as *mut _
     }
+
+    pub fn module_base_address(&self) -> Option<*mut c_void> {
+        None
+    }
 }

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -58,6 +58,7 @@ enum Frame {
     Deserialized {
         ip: usize,
         symbol_address: usize,
+        module_base_address: Option<usize>,
     },
 }
 
@@ -73,6 +74,16 @@ impl Frame {
         match *self {
             Frame::Raw(ref f) => f.symbol_address(),
             Frame::Deserialized { symbol_address, .. } => symbol_address as *mut c_void,
+        }
+    }
+
+    fn module_base_address(&self) -> Option<*mut c_void> {
+        match *self {
+            Frame::Raw(ref f) => f.module_base_address(),
+            Frame::Deserialized {
+                module_base_address,
+                ..
+            } => module_base_address.map(|addr| addr as *mut c_void),
         }
     }
 }
@@ -263,6 +274,18 @@ impl BacktraceFrame {
         self.frame.symbol_address() as *mut c_void
     }
 
+    /// Same as `Frame::module_base_address`
+    ///
+    /// # Required features
+    ///
+    /// This function requires the `std` feature of the `backtrace` crate to be
+    /// enabled, and the `std` feature is enabled by default.
+    pub fn module_base_address(&self) -> Option<*mut c_void> {
+        self.frame
+            .module_base_address()
+            .map(|addr| addr as *mut c_void)
+    }
+
     /// Returns the list of symbols that this frame corresponds to.
     ///
     /// Normally there is only one symbol per frame, but sometimes if a number
@@ -396,6 +419,7 @@ mod rustc_serialize_impls {
     struct SerializedFrame {
         ip: usize,
         symbol_address: usize,
+        module_base_address: Option<usize>,
         symbols: Option<Vec<BacktraceSymbol>>,
     }
 
@@ -409,6 +433,7 @@ mod rustc_serialize_impls {
                 frame: Frame::Deserialized {
                     ip: frame.ip,
                     symbol_address: frame.symbol_address,
+                    module_base_address: frame.module_base_address,
                 },
                 symbols: frame.symbols,
             })
@@ -424,6 +449,7 @@ mod rustc_serialize_impls {
             SerializedFrame {
                 ip: frame.ip() as usize,
                 symbol_address: frame.symbol_address() as usize,
+                module_base_address: frame.module_base_address().map(|addr| addr as usize),
                 symbols: symbols.clone(),
             }
             .encode(e)
@@ -444,6 +470,7 @@ mod serde_impls {
     struct SerializedFrame {
         ip: usize,
         symbol_address: usize,
+        module_base_address: Option<usize>,
         symbols: Option<Vec<BacktraceSymbol>>,
     }
 
@@ -456,6 +483,7 @@ mod serde_impls {
             SerializedFrame {
                 ip: frame.ip() as usize,
                 symbol_address: frame.symbol_address() as usize,
+                module_base_address: frame.module_base_address().map(|addr| addr as usize),
                 symbols: symbols.clone(),
             }
             .serialize(s)
@@ -472,6 +500,7 @@ mod serde_impls {
                 frame: Frame::Deserialized {
                     ip: frame.ip,
                     symbol_address: frame.symbol_address,
+                    module_base_address: frame.module_base_address,
                 },
                 symbols: frame.symbols,
             })

--- a/src/symbolize/dbghelp.rs
+++ b/src/symbolize/dbghelp.rs
@@ -27,7 +27,7 @@
 
 #![allow(bad_style)]
 
-use super::super::{backtrace::FrameImp as Frame, dbghelp, windows::*};
+use super::super::{backtrace::StackFrame, dbghelp, windows::*};
 use super::{BytesOrWideString, ResolveWhat, SymbolName};
 use core::char;
 use core::ffi::c_void;
@@ -86,9 +86,9 @@ pub unsafe fn resolve(what: ResolveWhat<'_>, cb: &mut dyn FnMut(&super::Symbol))
 
     match what {
         ResolveWhat::Address(_) => resolve_without_inline(&dbghelp, what.address_or_ip(), cb),
-        ResolveWhat::Frame(frame) => match &frame.inner {
-            Frame::New(frame) => resolve_with_inline(&dbghelp, frame, cb),
-            Frame::Old(_) => resolve_without_inline(&dbghelp, frame.ip(), cb),
+        ResolveWhat::Frame(frame) => match &frame.inner.stack_frame {
+            StackFrame::New(frame) => resolve_with_inline(&dbghelp, frame, cb),
+            StackFrame::Old(_) => resolve_without_inline(&dbghelp, frame.ip(), cb),
         },
     }
 }


### PR DESCRIPTION
The base address of the module is required on the Windows to decode a backtrace when a PDB file is moved or missing:
```
<address_in_pdb> = <instruction_pointer_address> - <module_base_address>
```

The struct `Frame` is extended with the following method:
```
pub fn module_base_address(&self) -> Option<*mut c_void>;
```

The method returns an Option, because only `dbghelp::Frame::module_base_address()` is implemented in this PR. And I'm not sure if the proposed method can be implemented for `libunwind::Frame`.