### PR TITLE
Fix compilation error on i686-apple-darwin targets

### DIFF
--- a/src/symbolize/gimli/macho.rs
+++ b/src/symbolize/gimli/macho.rs
@@ -161,7 +161,7 @@ impl<'a> Object<'a> {
                     .filter_map(|nlist: &MachNlist| {
                         let name = nlist.name(endian, symbols.strings()).ok()?;
                         if name.len() > 0 && !nlist.is_undefined() {
-                            Some((name, nlist.n_value(endian)))
+                            Some((name, u64::from(nlist.n_value(endian))))
                         } else {
                             None
                         }


### PR DESCRIPTION
`symbolize::gimli::macho::Object` expects `syms` to be a `Vec<(..., u64)>` but on i686 it gets initialized with a `Vec<(..., u32)>`. This just adds a cast to `u64` to the syms generator so it typechecks.