### PR TITLE
use NativeEndian in symbolize::gimli::Context

### DIFF
--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -5,7 +5,7 @@
 //! intended to wholesale replace the `libbacktrace.rs` implementation.
 
 use self::gimli::read::EndianSlice;
-use self::gimli::LittleEndian as Endian;
+use self::gimli::NativeEndian as Endian;
 use self::mmap::Mmap;
 use self::stash::Stash;
 use super::BytesOrWideString;


### PR DESCRIPTION
`Object` uses `NativeEndian`, so the `Context` should too.

Cc: https://github.com/rust-lang/rust/issues/77410