### PR TITLE
Enable Mach-O on iOS in gimli.

### DIFF
--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -201,7 +201,12 @@ cfg_if::cfg_if! {
                 }],
             })
         }
-    } else if #[cfg(any(target_os = "macos", target_os = "ios"))] {
+    } else if #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+    ))] {
         // macOS uses the Mach-O file format and uses DYLD-specific APIs to
         // load a list of native libraries that are part of the appplication.
 

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -201,7 +201,7 @@ cfg_if::cfg_if! {
                 }],
             })
         }
-    } else if #[cfg(target_os = "macos")] {
+    } else if #[cfg(any(target_os = "macos", target_os = "ios"))] {
         // macOS uses the Mach-O file format and uses DYLD-specific APIs to
         // load a list of native libraries that are part of the appplication.
 


### PR DESCRIPTION
Fixes for iOS rust-lang/rust#78184.

iOS uses the same Mach-O format as macOS does. I have confirmed that this fix works on `x86_64-apple-ios` (tier 2). I expect it will also work on `aarch64-apple-ios` (tier 2), `armv7-apple-ios`, `armv7s-apple-ios`, `i386-apple-ios`, `x86_64-apple-ios-macabi` (tier 3), but I don't have the hardware to test on all of those archs.

#### Tier 2:

- [x] `x86_64-apple-ios` compiles and works
- [x] `aarch64-apple-ios` compiles

#### Tier 3:
- [ ] `armv7-apple-ios`
- [ ] `armv7s-apple-ios`
- [ ] `i386-apple-ios`
- [ ] `x86_64-apple-ios-macabi`
- [ ] `aarch64-apple-tvos`
- [ ] `x86_64-apple-tvos`

#### Nightly?:
- [ ] `armv7k-apple-watchos`
- [ ] `i386-apple-watchos`
- [ ] `x86_64-apple-watchos`

(Thanks @bjorn3!)