### PR TITLE
Refactor gimli implementation to avoid `mk!` macro

### DIFF
--- a/src/symbolize/gimli/coff.rs
+++ b/src/symbolize/gimli/coff.rs
@@ -1,4 +1,4 @@
-use super::{Context, Mapping, Mmap, Path, Stash, Vec};
+use super::{Context, Mapping, Path, Stash, Vec};
 use core::convert::TryFrom;
 use object::pe::{ImageDosHeader, ImageSymbol};
 use object::read::pe::{ImageNtHeaders, ImageOptionalHeader, SectionTable};
@@ -13,9 +13,7 @@ type Pe = object::pe::ImageNtHeaders64;
 impl Mapping {
     pub fn new(path: &Path) -> Option<Mapping> {
         let map = super::mmap(path)?;
-        let stash = Stash::new();
-        let cx = super::cx(&stash, Object::parse(&map)?)?;
-        Some(mk!(Mapping { map, cx, stash }))
+        Mapping::mk(map, |data, stash| Context::new(stash, Object::parse(data)?))
     }
 }
 

--- a/src/symbolize/gimli/elf.rs
+++ b/src/symbolize/gimli/elf.rs
@@ -1,4 +1,4 @@
-use super::{Context, Mapping, Mmap, Path, Stash, Vec};
+use super::{Context, Mapping, Path, Stash, Vec};
 use core::convert::TryFrom;
 use object::elf::{ELFCOMPRESS_ZLIB, SHF_COMPRESSED};
 use object::read::elf::{CompressionHeader, FileHeader, SectionHeader, SectionTable, Sym};
@@ -13,9 +13,7 @@ type Elf = object::elf::FileHeader64<NativeEndian>;
 impl Mapping {
     pub fn new(path: &Path) -> Option<Mapping> {
         let map = super::mmap(path)?;
-        let stash = Stash::new();
-        let cx = super::cx(&stash, Object::parse(&map)?)?;
-        Some(mk!(Mapping { map, cx, stash }))
+        Mapping::mk(map, |data, stash| Context::new(stash, Object::parse(data)?))
     }
 }
 


### PR DESCRIPTION
This commit refactors a bit to avoid using a macro for constructing a
`Mapping` and instead adds a dedicated function. This is a bit easier to
navigate and will hopefully help deduplicate construction of a `Mapping`
as well.