### PR TITLE
Update gimli docs

### DIFF
--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -1,8 +1,6 @@
 //! Support for symbolication using the `gimli` crate on crates.io
 //!
-//! This implementation is largely a work in progress and is off by default for
-//! all platforms, but it's hoped to be developed over time! Long-term this is
-//! intended to wholesale replace the `libbacktrace.rs` implementation.
+//! This is the default symbolication implementation for Rust.
 
 use self::gimli::read::EndianSlice;
 use self::gimli::NativeEndian as Endian;


### PR DESCRIPTION
I believe gimli is now the default implementation.

Cc https://github.com/rust-lang/backtrace-rs/pull/373#discussion_r502059176