### PR TITLE
Fix compile warning

### DIFF
--- a/src/symbolize/gimli/elf.rs
+++ b/src/symbolize/gimli/elf.rs
@@ -161,7 +161,7 @@ impl<'a> Object<'a> {
         }
     }
 
-    pub(super) fn search_object_map(&self, _addr: u64) -> Option<(&Context, u64)> {
+    pub(super) fn search_object_map(&self, _addr: u64) -> Option<(&Context<'_>, u64)> {
         None
     }
 }


### PR DESCRIPTION
Fixes a warning: hidden lifetime parameters in types are deprecated