### PR TITLE
Add CI for s390x-unknown-linux-gnu

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,6 +139,7 @@ jobs:
         - i586-unknown-linux-gnu
         - i686-unknown-linux-gnu
         - powerpc64-unknown-linux-gnu
+        - s390x-unknown-linux-gnu
         - x86_64-pc-windows-gnu
         - x86_64-unknown-linux-gnu
         - x86_64-unknown-linux-musl

--- a/ci/docker/s390x-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/s390x-unknown-linux-gnu/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    ca-certificates \
+    libc6-dev \
+    gcc-s390x-linux-gnu \
+    libc6-dev-s390x-cross \
+    qemu-user \
+    # There seems to be a bug in processing mixed-architecture
+    # ld.so.cache files that causes crashes in some cases.  Work
+    # around this by simply deleting the cache for now.
+    && rm /etc/ld.so.cache
+
+ENV CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-linux-gnu-gcc \
+    CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_RUNNER="qemu-s390x -L /usr/s390x-linux-gnu" \
+    CC=s390x-linux-gnu-gcc

--- a/tests/concurrent-panics.rs
+++ b/tests/concurrent-panics.rs
@@ -14,7 +14,12 @@ fn main() {
     // so just skip these for CI. No other reason this can't run on those
     // platforms though.
     // Miri does not have support for re-execing a file
-    if cfg!(unix) && (cfg!(target_arch = "arm") || cfg!(target_arch = "aarch64")) || cfg!(miri) {
+    if cfg!(unix)
+        && (cfg!(target_arch = "arm")
+            || cfg!(target_arch = "aarch64")
+            || cfg!(target_arch = "s390x"))
+        || cfg!(miri)
+    {
         println!("test result: ok");
         return;
     }


### PR DESCRIPTION
This adds a Docker-based CI job for s390x-unknown-linux-gnu similar to previous existing ones.

Two interesting comments:

- I ran into random crashes, which turned out to be caused by issues with handling ld.so.cache in the target ld.so running under qemu.  The ld.so.cache file is shared between the host and target ld.so, and is supposedly capable of caching files from multiple architectures in a single file.  However, in the default Ubuntu multi-arch setup, unless you install the s390x version of libc (from ports), ld.so.conf will never refer to **any** s390x libraries in the first place, so the target ld.so will never find any cache entry.  That in itself should still be fine, but in some cases the target ld.so will simply crash in that scenario.  I haven't found out the exact cause, but it is related to which particular set of libraries happens to be installed on the host ...   As a workaround, I'm now simply deleting the ld.so.cache file in the container image.

- The concurrent-panics.rs test doesn't work because it spawns a second executable, which doesn't use the CARGO_TARGET_..._RUNNER wrapper.   I've tried to enable the automatic binfmt_misc based qemu handler, but it looks like this doesn't work in a docker container (at least not on the github installation) since binfmt_misc handlers are shared between the container and the host running the container.   As a workaround I'm simply skipping that test on s390x, as is already done (for the same reason) on arm and aarch64.
