### PR TITLE
Deny warnings on CI to keep codebase warning-free 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,10 +52,12 @@ jobs:
     - name: Install Rust (rustup)
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
+    - run: echo RUSTFLAGS=-Dwarnings >> $GITHUB_ENV
+      shell: bash
     # full fidelity of backtraces on 32-bit msvc requires frame pointers, so
     # enable that for our tests
     - name: Force frame pointers
-      run: echo RUSTFLAGS=-Cforce-frame-pointers >> $GITHUB_ENV
+      run: echo RUSTFLAGS="-Cforce-frame-pointers $RUSTFLAGS" >> $GITHUB_ENV
       shell: bash
       if: matrix.thing == 'windows-msvc32'
     - run: cargo build --manifest-path crates/backtrace-sys/Cargo.toml
@@ -99,6 +101,8 @@ jobs:
     - name: Install Rust
       run: rustup update stable --no-self-update && rustup default stable
       shell: bash
+    - run: echo RUSTFLAGS=-Dwarnings >> $GITHUB_ENV
+      shell: bash
     - run: rustup target add aarch64-pc-windows-msvc
     - run: cargo test --no-run --target aarch64-pc-windows-msvc
     - run: cargo test --no-run --target aarch64-pc-windows-msvc --features verify-winapi
@@ -122,6 +126,7 @@ jobs:
         submodules: true
     - run: rustup target add ${{ matrix.target }}
     - run: |
+        export RUSTFLAGS=-Dwarnings
         export SDK_PATH=`xcrun --show-sdk-path --sdk ${{ matrix.sdk }}`
         export RUSTFLAGS="-C link-arg=-isysroot -C link-arg=$SDK_PATH"
         cargo test --no-run --target ${{ matrix.target }}
@@ -156,6 +161,8 @@ jobs:
       run: rustup update stable && rustup default stable
     - run: rustup target add ${{ matrix.target }}
     - run: cargo generate-lockfile
+    - run: echo RUSTFLAGS=-Dwarnings >> $GITHUB_ENV
+      shell: bash
     - run: ./ci/run-docker.sh ${{ matrix.target }}
 
   rustfmt:
@@ -182,6 +189,8 @@ jobs:
     - name: Install Rust
       run: rustup update nightly && rustup default nightly
     - run: rustup target add ${{ matrix.target }}
+    - run: echo RUSTFLAGS=-Dwarnings >> $GITHUB_ENV
+      shell: bash
     - run: cargo build --target ${{ matrix.target }}
 
   msrv:

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -18,6 +18,7 @@ run() {
       --volume `pwd`/target:/checkout/target \
       --workdir /checkout \
       --privileged \
+      --env RUSTFLAGS \
       backtrace \
       bash \
       -c 'PATH=$PATH:/rust/bin exec ci/run.sh'

--- a/crates/cpp_smoke_test/tests/smoke.rs
+++ b/crates/cpp_smoke_test/tests/smoke.rs
@@ -9,7 +9,6 @@ extern "C" {
 
 #[test]
 #[ignore] // fixme(fitzgen/cpp_demangle#73)
-#[cfg(not(target_os = "windows"))]
 fn smoke_test_cpp() {
     static RAN_ASSERTS: AtomicBool = AtomicBool::new(false);
 

--- a/crates/dylib-dep/src/lib.rs
+++ b/crates/dylib-dep/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(improper_ctypes_definitions)]
+
 type Pos = (&'static str, u32);
 
 macro_rules! pos {

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -152,6 +152,7 @@ cfg_if::cfg_if! {
         mod dbghelp;
         use self::dbghelp::trace as trace_imp;
         pub(crate) use self::dbghelp::Frame as FrameImp;
+        #[cfg(target_env = "msvc")] // only used in dbghelp symbolize
         pub(crate) use self::dbghelp::StackFrame;
     } else {
         mod noop;

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -472,12 +472,10 @@ mod rustc_serialize_impls {
 
 #[cfg(feature = "serde")]
 mod serde_impls {
-    extern crate serde;
-
-    use self::serde::de::Deserializer;
-    use self::serde::ser::Serializer;
-    use self::serde::{Deserialize, Serialize};
     use super::*;
+    use serde::de::Deserializer;
+    use serde::ser::Serializer;
+    use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize)]
     struct SerializedFrame {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,10 @@
 extern crate std;
 
 // This is only used for gimli right now, so silence warnings elsewhere.
-#[cfg_attr(not(target_os = "linux"), allow(unused_extern_crates))]
+#[cfg_attr(
+    any(not(target_os = "linux"), not(feature = "gimli-symbolize")),
+    allow(unused_extern_crates)
+)]
 extern crate alloc;
 
 pub use self::backtrace::{trace_unsynchronized, Frame};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@
 // When we're building as part of libstd, silence all warnings since they're
 // irrelevant as this crate is developed out-of-tree.
 #![cfg_attr(backtrace_in_libstd, allow(warnings))]
+#![cfg_attr(not(feature = "std"), allow(dead_code))]
 
 #[cfg(feature = "std")]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,11 +57,9 @@
 #[macro_use]
 extern crate std;
 
-// This is only used for gimli right now, so silence warnings elsewhere.
-#[cfg_attr(
-    any(not(target_os = "linux"), not(feature = "gimli-symbolize")),
-    allow(unused_extern_crates)
-)]
+// This is only used for gimli right now, which is only used on some platforms,
+// so don't worry if it's unused in other configurations.
+#[allow(unused_extern_crates)]
 extern crate alloc;
 
 pub use self::backtrace::{trace_unsynchronized, Frame};

--- a/src/symbolize/dbghelp.rs
+++ b/src/symbolize/dbghelp.rs
@@ -214,3 +214,5 @@ unsafe fn cache(filename: Option<*const [u16]>) -> Option<::std::ffi::OsString> 
 
 #[cfg(not(feature = "std"))]
 unsafe fn cache(_filename: Option<*const [u16]>) {}
+
+pub unsafe fn clear_symbol_cache() {}

--- a/src/symbolize/gimli/coff.rs
+++ b/src/symbolize/gimli/coff.rs
@@ -101,7 +101,7 @@ impl<'a> Object<'a> {
         self.symbols[i].1.name(self.strings).ok()
     }
 
-    pub(super) fn search_object_map(&self, _addr: u64) -> Option<(&Context, u64)> {
+    pub(super) fn search_object_map(&self, _addr: u64) -> Option<(&Context<'_>, u64)> {
         None
     }
 }

--- a/src/symbolize/libbacktrace.rs
+++ b/src/symbolize/libbacktrace.rs
@@ -456,3 +456,5 @@ pub unsafe fn resolve(what: ResolveWhat<'_>, cb: &mut dyn FnMut(&super::Symbol))
         &mut syminfo_state as *mut _ as *mut _,
     );
 }
+
+pub unsafe fn clear_symbol_cache() {}

--- a/src/symbolize/miri.rs
+++ b/src/symbolize/miri.rs
@@ -52,3 +52,5 @@ impl<'a> Symbol<'a> {
         ))
     }
 }
+
+pub unsafe fn clear_symbol_cache() {}

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -159,7 +159,7 @@ pub unsafe fn resolve_unsynchronized<F>(addr: *mut c_void, mut cb: F)
 where
     F: FnMut(&Symbol),
 {
-    resolve_imp(ResolveWhat::Address(addr), &mut cb)
+    imp::resolve(ResolveWhat::Address(addr), &mut cb)
 }
 
 /// Same as `resolve_frame`, only unsafe as it's unsynchronized.
@@ -175,7 +175,7 @@ pub unsafe fn resolve_frame_unsynchronized<F>(frame: &Frame, mut cb: F)
 where
     F: FnMut(&Symbol),
 {
-    resolve_imp(ResolveWhat::Frame(frame), &mut cb)
+    imp::resolve(ResolveWhat::Frame(frame), &mut cb)
 }
 
 /// A trait representing the resolution of a symbol in a file.
@@ -191,7 +191,7 @@ pub struct Symbol {
     // TODO: this lifetime bound needs to be persisted eventually to `Symbol`,
     // but that's currently a breaking change. For now this is safe since
     // `Symbol` is only ever handed out by reference and can't be cloned.
-    inner: SymbolImp<'static>,
+    inner: imp::Symbol<'static>,
 }
 
 impl Symbol {
@@ -459,21 +459,17 @@ cfg_if::cfg_if! {
 pub fn clear_symbol_cache() {
     let _guard = crate::lock::lock();
     unsafe {
-        clear_symbol_cache_imp();
+        imp::clear_symbol_cache();
     }
 }
 
 cfg_if::cfg_if! {
     if #[cfg(miri)] {
         mod miri;
-        use self::miri::resolve as resolve_imp;
-        use self::miri::Symbol as SymbolImp;
-        unsafe fn clear_symbol_cache_imp() {}
+        use miri as imp;
     } else if #[cfg(all(windows, target_env = "msvc", not(target_vendor = "uwp")))] {
         mod dbghelp;
-        use self::dbghelp::resolve as resolve_imp;
-        use self::dbghelp::Symbol as SymbolImp;
-        unsafe fn clear_symbol_cache_imp() {}
+        use dbghelp as imp;
     } else if #[cfg(all(
         feature = "libbacktrace",
         any(unix, all(windows, not(target_vendor = "uwp"), target_env = "gnu")),
@@ -483,9 +479,7 @@ cfg_if::cfg_if! {
         not(target_env = "libnx"),
     ))] {
         mod libbacktrace;
-        use self::libbacktrace::resolve as resolve_imp;
-        use self::libbacktrace::Symbol as SymbolImp;
-        unsafe fn clear_symbol_cache_imp() {}
+        use libbacktrace as imp;
     } else if #[cfg(all(
         feature = "gimli-symbolize",
         any(unix, windows),
@@ -493,14 +487,9 @@ cfg_if::cfg_if! {
         not(target_os = "emscripten"),
     ))] {
         mod gimli;
-        use self::gimli::resolve as resolve_imp;
-        use self::gimli::Symbol as SymbolImp;
-        use self::gimli::clear_symbol_cache as clear_symbol_cache_imp;
+        use gimli as imp;
     } else {
         mod noop;
-        use self::noop::resolve as resolve_imp;
-        use self::noop::Symbol as SymbolImp;
-        #[allow(unused)]
-        unsafe fn clear_symbol_cache_imp() {}
+        use noop as imp;
     }
 }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -383,7 +383,7 @@ fn format_symbol_name(
 cfg_if::cfg_if! {
     if #[cfg(feature = "cpp_demangle")] {
         impl<'a> fmt::Display for SymbolName<'a> {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 if let Some(ref s) = self.demangled {
                     s.fmt(f)
                 } else if let Some(ref cpp) = self.cpp_demangled.0 {
@@ -409,7 +409,7 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "std", feature = "cpp_demangle"))] {
         impl<'a> fmt::Debug for SymbolName<'a> {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 use std::fmt::Write;
 
                 if let Some(ref s) = self.demangled {

--- a/src/symbolize/noop.rs
+++ b/src/symbolize/noop.rs
@@ -37,3 +37,5 @@ impl Symbol<'_> {
         None
     }
 }
+
+pub unsafe fn clear_symbol_cache() {}


### PR DESCRIPTION


There's a ton of platforms here that we compile for and so it's only
really all covered on CI. To help keep warnings out for everyone let's
deny warnings on CI.

