### PR TITLE
Fix missing symbols on armv5te-unknown-linux-uclibceabi

### DIFF
--- a/src/backtrace/libunwind.rs
+++ b/src/backtrace/libunwind.rs
@@ -142,6 +142,14 @@ mod uw {
     pub type _Unwind_Trace_Fn =
         extern "C" fn(ctx: *mut _Unwind_Context, arg: *mut c_void) -> _Unwind_Reason_Code;
 
+    cfg_if::cfg_if! {
+        if #[cfg(all(target_os = "linux", target_env = "uclibc"))] {
+            // required libraries in the Linux uClibc environment
+            #[link(name = "gcc_s")]
+            extern {}
+        }
+    }
+
     extern "C" {
         // No native _Unwind_Backtrace on iOS
         #[cfg(not(all(target_os = "ios", target_arch = "arm")))]


### PR DESCRIPTION
I'm getting the following linker error when trying to build my app in the Linux uClibc environment:
```
/home/operutka/goodcam/goodcam-server/target/armv5te-unknown-linux-uclibceabi/release/deps/goodcam_server-aefb92c403e8cd55.goodcam_server.dzc3futp-cgu.0.rcgu.o: In function `_$LT$std..sys_common..backtrace.._print..DisplayBacktrace$u20$as$u20$core..fmt..Display$GT$::fmt::h767c7c95f7aba0d7':
      goodcam_server.dzc3futp-cgu.0:(.text._ZN91_$LT$std..sys_common..backtrace.._print..DisplayBacktrace$u20$as$u20$core..fmt..Display$GT$3fmt17h767c7c95f7aba0d7E+0x1c0): undefined reference to `_Unwind_Backtrace'
/home/operutka/goodcam/goodcam-server/target/armv5te-unknown-linux-uclibceabi/release/deps/goodcam_server-aefb92c403e8cd55.goodcam_server.dzc3futp-cgu.0.rcgu.o: In function `std::backtrace_rs::backtrace::libunwind::Frame::ip::hd4d0aaad97b49321':
      goodcam_server.dzc3futp-cgu.0:(.text._ZN3std12backtrace_rs9backtrace9libunwind5Frame2ip17hd4d0aaad97b49321E+0x3c): undefined reference to `_Unwind_VRS_Get'
```

Those symbols are available in the `gcc_s` lib. This change fixes the issue for me.

_Note: I'm building my own std using the unstable build-std Cargo feature._