### PR TITLE
Use the symbol table if the DWARF only has line numbers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,8 @@ jobs:
       if: contains(matrix.os, 'ubuntu')
     - run: cargo clean && RUSTFLAGS="-Z run-dsymutil=no" cargo test --features gimli-symbolize
       if: matrix.thing == 'macos-nightly'
+    - run: cargo clean && RUSTFLAGS="-Z split-dwarf=split -C save-temps" cargo test --features gimli-symbolize
+      if: matrix.thing == 'nightly'
     - run: cargo build --manifest-path crates/as-if-std/Cargo.toml
 
   windows_arm64:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ cpp_demangle = { default-features = false, version = "0.3.0", optional = true }
 
 # Optional dependencies enabled through the `gimli-symbolize` feature, do not
 # use these features directly.
-addr2line = { version = "0.14.0", optional = true, default-features = false }
+addr2line = { version = "0.14.1", optional = true, default-features = false }
 miniz_oxide = { version = "0.4.0", optional = true, default-features = false }
 [dependencies.object]
 version = "0.22"

--- a/crates/as-if-std/Cargo.toml
+++ b/crates/as-if-std/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 cfg-if = "1.0"
 rustc-demangle = "0.1.4"
 libc = { version = "0.2.45", default-features = false }
-addr2line = { version = "0.14.0", default-features = false }
+addr2line = { version = "0.14.1", default-features = false }
 miniz_oxide = { version = "0.4.0", default-features = false }
 
 [dependencies.object]

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -621,10 +621,14 @@ pub unsafe fn resolve(what: ResolveWhat<'_>, cb: &mut dyn FnMut(&super::Symbol))
         if let Ok(mut frames) = cx.dwarf.find_frames(addr as u64) {
             while let Ok(Some(frame)) = frames.next() {
                 any_frames = true;
+                let name = match frame.function {
+                    Some(f) => Some(f.name.slice()),
+                    None => cx.object.search_symtab(addr as u64),
+                };
                 call(Symbol::Frame {
                     addr: addr as *mut c_void,
                     location: frame.location,
-                    name: frame.function.map(|f| f.name.slice()),
+                    name,
                 });
             }
         }


### PR DESCRIPTION
This can occur for skeleton units in split DWARF. Also bump addr2line to 0.14.1 to get a related fix there so that it returns the location in this case.

This fixes backtraces with `RUSTFLAGS="-Z split-dwarf=split -C save-temps"`.