### PR TITLE
implement From<Frame> for BacktraceFrame

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -249,6 +249,15 @@ impl From<Vec<BacktraceFrame>> for Backtrace {
     }
 }
 
+impl From<crate::Frame> for BacktraceFrame {
+    fn from(frame: crate::Frame) -> BacktraceFrame {
+        BacktraceFrame {
+            frame: Frame::Raw(frame),
+            symbols: None,
+        }
+    }
+}
+
 impl Into<Vec<BacktraceFrame>> for Backtrace {
     fn into(self) -> Vec<BacktraceFrame> {
         self.frames

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -551,7 +551,6 @@ mod tests {
         manual.resolve();
         let frames = manual.frames();
 
-        let mut total_symbols = 0;
         // the first frames can be different because we call from slightly different places,
         // and the `trace` version has an extra capture. But because of inlining the number of
         // frames that differ may be different between release and debug versions. Plus who knows
@@ -574,7 +573,6 @@ mod tests {
 
             assert_eq!(og_symbols.len(), converted_symbols.len());
             for (os, cs) in og_symbols.iter().zip(converted_symbols.iter()) {
-                total_symbols += 1;
                 assert_eq!(
                     os.name().map(|x| x.as_bytes()),
                     cs.name().map(|x| x.as_bytes())
@@ -583,6 +581,5 @@ mod tests {
                 assert_eq!(os.lineno(), cs.lineno());
             }
         }
-        assert_ne!(total_symbols, 0);
     }
 }


### PR DESCRIPTION
There are situations where we can only capture raw `Frame` (example:
capturing from a signal handler), but it could still be that we can
process them later and are not fully nostd in the environment.

With a conversion from Frame to BacktraceFrame, this is trivial. But
without it, we can't really use the pretty printers as they are reliant
on BacktraceFrame, not Frame.

Fixes: #419