### PR TITLE
Allow android C compile to fail

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,13 @@ fn main() {
 }
 
 fn build_android() {
-    let expansion = cc::Build::new().file("src/android-api.c").expand();
+    let expansion = match cc::Build::new().file("src/android-api.c").try_expand() {
+        Ok(result) => result,
+        Err(e) => {
+            println!("failed to run C compiler: {}", e);
+            return;
+        }
+    };
     let expansion = match std::str::from_utf8(&expansion) {
         Ok(s) => s,
         Err(_) => return,


### PR DESCRIPTION
A C compiler hasn't been required historically, so let's assume we don't
know the API version if the C compiler fails.

Closes #424