### PR TITLE
elf: support external and supplementary debuginfo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,6 +102,10 @@ jobs:
       env:
         RUSTFLAGS: "-C split-debuginfo=packed -Zunstable-options"
 
+    # Test that separate debug info works
+    - run: ./ci/debuglink-docker.sh
+      if: contains(matrix.os, 'ubuntu')
+
     # Test that including as a submodule will still work
     - run: cargo build --manifest-path crates/as-if-std/Cargo.toml
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,12 @@ edition = "2018"
 
 [workspace]
 members = ['crates/cpp_smoke_test', 'crates/as-if-std']
-exclude = ['crates/without_debuginfo', 'crates/macos_frames_test', 'crates/line-tables-only']
+exclude = [
+   'crates/without_debuginfo',
+   'crates/macos_frames_test',
+   'crates/line-tables-only',
+   'crates/debuglink',
+]
 
 [dependencies]
 cfg-if = "1.0"

--- a/ci/debuglink-docker.sh
+++ b/ci/debuglink-docker.sh
@@ -1,0 +1,29 @@
+# Small script to run debuglink tests inside a docker image.
+# Creates a writable mount on /usr/lib/debug.
+
+set -ex
+
+run() {
+    cargo generate-lockfile --manifest-path crates/debuglink/Cargo.toml
+    mkdir -p target crates/debuglink/target debug
+    docker build -t backtrace -f ci/docker/$1/Dockerfile ci
+    docker run \
+      --user `id -u`:`id -g` \
+      --rm \
+      --init \
+      --volume $(dirname $(dirname `which cargo`)):/cargo \
+      --env CARGO_HOME=/cargo \
+      --volume `rustc --print sysroot`:/rust:ro \
+      --env TARGET=$1 \
+      --volume `pwd`:/checkout:ro \
+      --volume `pwd`/target:/checkout/crates/debuglink/target \
+      --workdir /checkout \
+      --volume `pwd`/debug:/usr/lib/debug \
+      --privileged \
+      --env RUSTFLAGS \
+      backtrace \
+      bash \
+      -c 'PATH=$PATH:/rust/bin exec ci/debuglink.sh'
+}
+
+run x86_64-unknown-linux-gnu

--- a/ci/debuglink.sh
+++ b/ci/debuglink.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Debuglink tests.
+# We build crates/debuglink and then move its debuginfo around
+# and test that it can still find the debuginfo.
+
+set -ex
+
+cratedir=`pwd`/crates/debuglink
+exefile=crates/debuglink/target/debug/debuglink
+
+# Baseline; no separate debug
+cargo build --manifest-path crates/debuglink/Cargo.toml
+$exefile $cratedir
+
+# Separate debug in same dir
+debugfile1=`dirname $exefile`/debuglink.debug
+objcopy --only-keep-debug $exefile $debugfile1
+strip -g $exefile
+(cd `dirname $exefile` && objcopy --add-gnu-debuglink=debuglink.debug debuglink)
+$exefile $cratedir
+
+# Separate debug in .debug subdir
+debugfile2=`dirname $exefile`/.debug/debuglink.debug
+mkdir -p `dirname $debugfile2`
+mv $debugfile1 $debugfile2
+$exefile $cratedir
+
+# Separate debug in /usr/lib/debug subdir
+debugfile3="/usr/lib/debug/$cratedir/target/debug/debuglink.debug"
+mkdir -p `dirname $debugfile3`
+mv $debugfile2 $debugfile3
+$exefile $cratedir
+
+# Separate debug in /usr/lib/debug/.build-id subdir
+id=`readelf -n $exefile | grep '^    Build ID: [0-9a-f]' | cut -b 15-`
+idfile="/usr/lib/debug/.build-id/${id:0:2}/${id:2}.debug"
+mkdir -p `dirname $idfile`
+mv $debugfile3 $idfile
+$exefile $cratedir
+
+# Replace idfile with a symlink (this is the usual arrangement)
+mv $idfile $debugfile3
+ln -s $debugfile3 $idfile
+$exefile $cratedir
+
+# Supplementary object file using relative path
+dwzfile="/usr/lib/debug/.dwz/debuglink.debug"
+mkdir -p `dirname $dwzfile`
+cp $debugfile3 $debugfile3.copy
+dwz -m $dwzfile -rh $debugfile3 $debugfile3.copy
+rm $debugfile3.copy
+$exefile $cratedir
+
+# Supplementary object file using build ID
+dwzid=`readelf -n $dwzfile | grep '^    Build ID: [0-9a-f]' | cut -b 15-`
+dwzidfile="/usr/lib/debug/.build-id/${dwzid:0:2}/${dwzid:2}.debug"
+mkdir -p `dirname $dwzidfile`
+mv $dwzfile $dwzidfile
+$exefile $cratedir
+mv $dwzidfile $dwzfile
+
+# Missing debug should fail
+mv $debugfile3 $debugfile3.tmp
+! $exefile $cratedir
+mv $debugfile3.tmp $debugfile3
+
+# Missing dwz should fail
+mv $dwzfile $dwzfile.tmp
+! $exefile $cratedir
+mv $dwzfile.tmp $dwzfile
+
+# Cleanup
+rm $idfile $debugfile3 $dwzfile
+echo Success

--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -2,4 +2,5 @@ FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
   gcc \
   libc6-dev \
-  ca-certificates
+  ca-certificates \
+  dwz

--- a/crates/debuglink/Cargo.toml
+++ b/crates/debuglink/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "debuglink"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+backtrace = { path = "../.." }

--- a/crates/debuglink/src/main.rs
+++ b/crates/debuglink/src/main.rs
@@ -1,0 +1,34 @@
+// Test that the debuginfo is being found by checking that the
+// backtrace contains `main` and that the source filename uses
+// the path given in the command line arguments.
+//
+// For dwz tests, this assumes that the path string will be moved into
+// the dwz file.
+fn main() {
+    let crate_dir = std::env::args().skip(1).next().unwrap();
+    let expect = std::path::Path::new(&crate_dir).join("src/main.rs");
+
+    let bt = backtrace::Backtrace::new();
+    println!("{:?}", bt);
+
+    let mut found_main = false;
+
+    for frame in bt.frames() {
+        let symbols = frame.symbols();
+        if symbols.is_empty() {
+            continue;
+        }
+
+        if let Some(name) = symbols[0].name() {
+            let name = format!("{:#}", name);
+            if name == "debuglink::main" {
+                found_main = true;
+                let filename = symbols[0].filename().unwrap();
+                assert_eq!(filename, expect);
+                break;
+            }
+        }
+    }
+
+    assert!(found_main);
+}

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -62,6 +62,7 @@ struct Mapping {
 }
 
 impl Mapping {
+    #[allow(dead_code)]
     fn mk<F>(data: Mmap, mk: F) -> Option<Mapping>
     where
         F: for<'a> Fn(&'a [u8], &'a Stash) -> Option<Context<'a>>,

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -87,35 +87,27 @@ struct Context<'a> {
 }
 
 impl<'data> Context<'data> {
-    fn new(stash: &'data Stash, object: Object<'data>) -> Option<Context<'data>> {
-        let sections = gimli::Dwarf::load(|id| -> Result<_, ()> {
-            let data = object.section(stash, id.name()).unwrap_or(&[]);
-            Ok(EndianSlice::new(data, Endian))
-        })
-        .ok()?;
-        let dwarf = addr2line::Context::from_dwarf(sections).ok()?;
-
-        Some(Context { dwarf, object })
-    }
-
-    #[allow(dead_code)]
-    fn new_sup(
+    fn new(
         stash: &'data Stash,
         object: Object<'data>,
-        sup: Object<'data>,
+        sup: Option<Object<'data>>,
     ) -> Option<Context<'data>> {
         let mut sections = gimli::Dwarf::load(|id| -> Result<_, ()> {
             let data = object.section(stash, id.name()).unwrap_or(&[]);
             Ok(EndianSlice::new(data, Endian))
         })
         .ok()?;
-        sections
-            .load_sup(|id| -> Result<_, ()> {
-                let data = sup.section(stash, id.name()).unwrap_or(&[]);
-                Ok(EndianSlice::new(data, Endian))
-            })
-            .ok()?;
+
+        if let Some(sup) = sup {
+            sections
+                .load_sup(|id| -> Result<_, ()> {
+                    let data = sup.section(stash, id.name()).unwrap_or(&[]);
+                    Ok(EndianSlice::new(data, Endian))
+                })
+                .ok()?;
+        }
         let dwarf = addr2line::Context::from_dwarf(sections).ok()?;
+
         Some(Context { dwarf, object })
     }
 }

--- a/src/symbolize/gimli/coff.rs
+++ b/src/symbolize/gimli/coff.rs
@@ -13,7 +13,9 @@ type Pe = object::pe::ImageNtHeaders64;
 impl Mapping {
     pub fn new(path: &Path) -> Option<Mapping> {
         let map = super::mmap(path)?;
-        Mapping::mk(map, |data, stash| Context::new(stash, Object::parse(data)?))
+        Mapping::mk(map, |data, stash| {
+            Context::new(stash, Object::parse(data)?, None)
+        })
     }
 }
 

--- a/src/symbolize/gimli/elf.rs
+++ b/src/symbolize/gimli/elf.rs
@@ -251,6 +251,8 @@ impl<'a> Object<'a> {
         None
     }
 
+    // The format of build id paths is documented at:
+    // https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
     fn build_id_debug_path(&self) -> Option<PathBuf> {
         const BUILD_ID_PATH: &[u8] = b"/usr/lib/debug/.build-id/";
         const BUILD_ID_SUFFIX: &[u8] = b".debug";
@@ -283,6 +285,8 @@ impl<'a> Object<'a> {
         Some(PathBuf::from(OsString::from_vec(path)))
     }
 
+    // The contents of the ".gnu_debuglink" section is documented at:
+    // https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
     fn gnu_debuglink_path(&self, path: &Path) -> Option<(PathBuf, u32)> {
         let section = self.section_header(".gnu_debuglink")?;
         let data = section.data(self.endian, self.data).ok()?;
@@ -297,6 +301,7 @@ impl<'a> Object<'a> {
         Some((path_debug, crc))
     }
 
+    // The format if the ".gnu_debugaltlink" section is based on gdb.
     fn gnu_debugaltlink_path(&self, path: &Path) -> Option<(PathBuf, &'a [u8])> {
         let section = self.section_header(".gnu_debugaltlink")?;
         let data = section.data(self.endian, self.data).ok()?;
@@ -329,6 +334,8 @@ fn decompress_zlib(input: &[u8], output: &mut [u8]) -> Option<()> {
     }
 }
 
+// Search order matches gdb, documented at:
+// https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
 fn locate_debuglink(path: &Path, filename: &[u8]) -> Option<PathBuf> {
     const DEBUG_PATH: &[u8] = b"/usr/lib/debug";
     let path = fs::canonicalize(path).ok()?;

--- a/src/symbolize/gimli/elf.rs
+++ b/src/symbolize/gimli/elf.rs
@@ -434,7 +434,9 @@ fn locate_debugaltlink(path: &Path, filename: &[u8], build_id: &[u8]) -> Option<
             return Some(filename.into());
         }
     } else {
-        let mut f = PathBuf::from(path);
+        let path = fs::canonicalize(path).ok()?;
+        let parent = path.parent()?;
+        let mut f = PathBuf::from(parent);
         f.push(filename);
         if f.is_file() {
             return Some(f);

--- a/src/symbolize/gimli/elf.rs
+++ b/src/symbolize/gimli/elf.rs
@@ -71,7 +71,7 @@ impl Mapping {
         }
 
         let stash = Stash::new();
-        let cx = Context::new(&stash, object)?;
+        let cx = Context::new(&stash, object, None)?;
         Some(Mapping {
             // Convert to 'static lifetimes since the symbols should
             // only borrow `map` and `stash` and we're preserving them below.
@@ -102,7 +102,7 @@ impl Mapping {
                         if let Some(sup) = Object::parse(&map_sup) {
                             if sup.build_id() == Some(build_id_sup) {
                                 let stash = Stash::new();
-                                let cx = Context::new_sup(&stash, object, sup)?;
+                                let cx = Context::new(&stash, object, Some(sup))?;
                                 return Some(Mapping {
                                     // Convert to 'static lifetimes since the symbols should
                                     // only borrow `map`, `map_sup`, and `stash` and we're
@@ -122,7 +122,7 @@ impl Mapping {
         }
 
         let stash = Stash::new();
-        let cx = Context::new(&stash, object)?;
+        let cx = Context::new(&stash, object, None)?;
         Some(Mapping {
             // Convert to 'static lifetimes since the symbols should
             // only borrow `map` and `stash` and we're preserving them below.

--- a/src/symbolize/gimli/macho.rs
+++ b/src/symbolize/gimli/macho.rs
@@ -43,7 +43,7 @@ impl Mapping {
             let (macho, data) = find_header(data)?;
             let endian = macho.endian().ok()?;
             let obj = Object::parse(macho, endian, data)?;
-            Context::new(stash, obj)
+            Context::new(stash, obj, None)
         })
     }
 
@@ -80,7 +80,7 @@ impl Mapping {
                     return None;
                 }
                 let obj = Object::parse(macho, endian, data)?;
-                Context::new(stash, obj)
+                Context::new(stash, obj, None)
             });
             if let Some(candidate) = candidate {
                 return Some(candidate);
@@ -307,7 +307,7 @@ fn object_mapping(path: &[u8]) -> Option<Mapping> {
         let (macho, data) = find_header(data)?;
         let endian = macho.endian().ok()?;
         let obj = Object::parse(macho, endian, data)?;
-        Context::new(stash, obj)
+        Context::new(stash, obj, None)
     })
 }
 


### PR DESCRIPTION
Fixes #410 

Doesn't check the CRC for GNU debuglink. I'm not sure how important this is, and it would require adding a dependency (`crc32fast`?).

Doesn't add any tests; I'm unsure how to test this in CI. I have manually tested that the `backtrace` example can give line number information for `__libc_start_main`, which tests the build ID on Fedora, and the GNU debuglink on Ubuntu. I have manually tested the supplementary object file support using the `backtrace` and `raw` examples after running the following commands:
```
objcopy --only-keep-debug target/debug/examples/backtrace target/debug/examples/backtrace.debug
strip -g target/debug/examples/backtrace
(cd target/debug/examples; objcopy --add-gnu-debuglink=backtrace.debug backtrace)

mkdir -p target/debug/examples/.debug
objcopy --only-keep-debug target/debug/examples/raw target/debug/examples/.debug/raw.debug
strip -g target/debug/examples/raw
(cd target/debug/examples/.debug; objcopy --add-gnu-debuglink=raw.debug ../raw)

mkdir -p .dwz
dwz -m .dwz/backtrace.debug -rh target/debug/examples/backtrace.debug target/debug/examples/.debug/raw.debug
```