### PR TITLE
Import some items from winapi as they are now present

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ default-features = false
 features = ['read_core', 'elf', 'macho', 'pe', 'unaligned', 'archive']
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.3", optional = true }
+winapi = { version = "0.3.9", optional = true }
 
 [build-dependencies]
 # Only needed for Android, but cannot be target dependent

--- a/src/dbghelp.rs
+++ b/src/dbghelp.rs
@@ -158,7 +158,7 @@ const SYMOPT_DEFERRED_LOADS: DWORD = 0x00000004;
 dbghelp! {
     extern "system" {
         fn SymGetOptions() -> DWORD;
-        fn SymSetOptions(options: DWORD) -> ();
+        fn SymSetOptions(options: DWORD) -> DWORD;
         fn SymInitializeW(
             handle: HANDLE,
             path: PCWSTR,

--- a/src/dbghelp.rs
+++ b/src/dbghelp.rs
@@ -34,29 +34,11 @@ use core::ptr;
 mod dbghelp {
     use crate::windows::*;
     pub use winapi::um::dbghelp::{
-        StackWalk64, SymCleanup, SymFromAddrW, SymFunctionTableAccess64, SymGetLineFromAddrW64,
-        SymGetModuleBase64, SymInitializeW,
+        StackWalk64, StackWalkEx, SymCleanup, SymFromAddrW, SymFunctionTableAccess64,
+        SymGetLineFromAddrW64, SymGetModuleBase64, SymGetOptions, SymInitializeW, SymSetOptions,
     };
 
     extern "system" {
-        // Not defined in winapi yet
-        pub fn SymGetOptions() -> u32;
-        pub fn SymSetOptions(_: u32);
-
-        // This is defined in winapi, but it's incorrect (FIXME winapi-rs#768)
-        pub fn StackWalkEx(
-            MachineType: DWORD,
-            hProcess: HANDLE,
-            hThread: HANDLE,
-            StackFrame: LPSTACKFRAME_EX,
-            ContextRecord: PVOID,
-            ReadMemoryRoutine: PREAD_PROCESS_MEMORY_ROUTINE64,
-            FunctionTableAccessRoutine: PFUNCTION_TABLE_ACCESS_ROUTINE64,
-            GetModuleBaseRoutine: PGET_MODULE_BASE_ROUTINE64,
-            TranslateAddress: PTRANSLATE_ADDRESS_ROUTINE64,
-            Flags: DWORD,
-        ) -> BOOL;
-
         // Not defined in winapi yet
         pub fn SymFromInlineContextW(
             hProcess: HANDLE,


### PR DESCRIPTION
https://github.com/retep998/winapi-rs/issues/768 has been fixed now, and `SymGetOptions`/`SymSetOptions` were added by retep998/winapi-rs#864. This also updates the patch version so that someone doesn't pull an older version mistakenly.