### PR TITLE
Fix crate as an optional dep of libstd

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,8 +106,10 @@ jobs:
     - run: ./ci/debuglink-docker.sh
       if: contains(matrix.os, 'ubuntu')
 
-    # Test that including as a submodule will still work
+    # Test that including as a submodule will still work, both with and without
+    # the `backtrace` feature enabled.
     - run: cargo build --manifest-path crates/as-if-std/Cargo.toml
+    - run: cargo build --manifest-path crates/as-if-std/Cargo.toml --no-default-features
 
   windows_arm64:
     name: Windows AArch64

--- a/crates/as-if-std/Cargo.toml
+++ b/crates/as-if-std/Cargo.toml
@@ -15,14 +15,15 @@ bench = false
 cfg-if = "1.0"
 rustc-demangle = "0.1.4"
 libc = { version = "0.2.45", default-features = false }
-addr2line = { version = "0.15.1", default-features = false }
+addr2line = { version = "0.16.0", default-features = false, optional = true }
 miniz_oxide = { version = "0.4.0", default-features = false }
 
 [dependencies.object]
-version = "0.25"
+version = "0.26"
 default-features = false
+optional = true
 features = ['read_core', 'elf', 'macho', 'pe', 'unaligned', 'archive']
 
 [features]
-default = ['gimli-symbolize']
-gimli-symbolize = []
+default = ['backtrace']
+backtrace = ['addr2line', 'object']

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -474,6 +474,7 @@ cfg_if::cfg_if! {
         any(unix, windows),
         not(target_vendor = "uwp"),
         not(target_os = "emscripten"),
+        any(not(backtrace_in_libstd), feature = "backtrace"),
     ))] {
         mod gimli;
         use gimli as imp;


### PR DESCRIPTION
This was broken in a previous refactoring by accident, and this restores
support.