### PR TITLE
Add more support for OpenBSD

### DIFF
--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -177,6 +177,7 @@ cfg_if::cfg_if! {
             target_os = "linux",
             target_os = "fuchsia",
             target_os = "freebsd",
+            target_os = "openbsd",
             all(target_os = "android", feature = "dl_iterate_phdr"),
         ),
         not(target_env = "uclibc"),


### PR DESCRIPTION
Previously the backtrace example would print a useless backtrace:
```
     Running `target/debug/examples/backtrace`
   0: <unknown>
   1: <unknown>
   2: <unknown>
   3: <unknown>
   4: <unknown>
   5: <unknown>
   6: <unknown>
   7: <unknown>
```
Now its slightly more useful
```
     Running `target/debug/examples/backtrace`
   0: backtrace::main
             at examples/backtrace.rs:4:22
   1: core::ops::function::FnOnce::call_once
             at /usr/obj/ports/rust-1.54.0/rustc-1.54.0-src/library/core/src/ops/function.rs:227:5
   2: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /usr/obj/ports/rust-1.54.0/rustc-1.54.0-src/library/std/src/sys_common/backtrace.rs:125:18
   3: std::rt::lang_start::{{closure}}
             at /usr/obj/ports/rust-1.54.0/rustc-1.54.0-src/library/std/src/rt.rs:49:18
   4: std::rt::lang_start_internal
   5: std::rt::lang_start
             at /usr/obj/ports/rust-1.54.0/rustc-1.54.0-src/library/std/src/rt.rs:48:5
   6: main
   7: <unknown>
```
I do not know for sure why it cannot trace back to before main, could be a bug
in backtrace-rs or a security measure by OpenBSD. However for the average user
this step of the backtrace should be irrelevant on OpenBSD so this is still a
great improvement to before.