### PR TITLE
Don't require a UUID in Mach-O binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,6 +91,11 @@ jobs:
       env:
         CARGO_PROFILE_DEV_SPLIT_DEBUGINFO: packed
         CARGO_PROFILE_TEST_SPLIT_DEBUGINFO: packed
+    # Test that, on macOS, binaries with no UUID work
+    - run: cargo clean && cargo test
+      if: matrix.os == 'macos-latest'
+      env:
+        RUSTFLAGS: "-C link-arg=-Wl,-no_uuid"
 
     # Test that, on Linux, packed/unpacked debuginfo both work
     - run: cargo clean && cargo test

--- a/src/symbolize/gimli/macho.rs
+++ b/src/symbolize/gimli/macho.rs
@@ -22,7 +22,7 @@ impl Mapping {
         let map = super::mmap(path)?;
         let (macho, data) = find_header(&map)?;
         let endian = macho.endian().ok()?;
-        let uuid = macho.uuid(endian, data, 0).ok()??;
+        let uuid = macho.uuid(endian, data, 0).ok()?;
 
         // Next we need to look for a `*.dSYM` file. For now we just probe the
         // containing directory and look around for something that matches
@@ -30,9 +30,11 @@ impl Mapping {
         // contains and try to find a macho file which has a matching UUID as
         // the one of our own file. If we find a match that's the dwarf file we
         // want to return.
-        if let Some(parent) = path.parent() {
-            if let Some(mapping) = Mapping::load_dsym(parent, uuid) {
-                return Some(mapping);
+        if let Some(uuid) = uuid {
+            if let Some(parent) = path.parent() {
+                if let Some(mapping) = Mapping::load_dsym(parent, uuid) {
+                    return Some(mapping);
+                }
             }
         }
 


### PR DESCRIPTION
Some Mach-O binaries do not contain the `LC_UUID` command, such as those [built with Nix](https://github.com/NixOS/nixpkgs/blob/3708f33517029d8653d3d03f9619f219679d5027/pkgs/build-support/bintools-wrapper/default.nix#L331), so this PR removes the requirement for one to exist.

This fixes #443.