### PR TITLE
Make rustc-demangle optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ exclude = [
 
 [dependencies]
 cfg-if = "1.0"
-rustc-demangle = "0.1.4"
+rustc-demangle = { version = "0.1.4", optional = true }
 libc = { version = "0.2.94", default-features = false }
 
 # Optionally enable the ability to serialize a `Backtrace`, controlled through
@@ -35,7 +35,8 @@ serde = { version = "1.0", optional = true, features = ['derive'] }
 rustc-serialize = { version = "0.3", optional = true }
 
 # Optionally demangle C++ frames' symbols in backtraces.
-cpp_demangle = { default-features = false, version = "0.3.0", optional = true }
+# Renamed so we can have a cpp_demangle feature.
+cpp_demangle_crate = { package = "cpp_demangle", default-features = false, version = "0.3.0", optional = true }
 
 
 # Optional dependencies enabled through the `gimli-symbolize` feature, do not
@@ -61,10 +62,12 @@ libloading = "0.7"
 
 [features]
 # By default libstd support and gimli-symbolize is used to symbolize addresses.
-default = ["std"]
+default = ["std", "rustc-demangle"]
 
 # Include std support. This enables types like `Backtrace`.
 std = []
+
+cpp_demangle = ["cpp_demangle_crate", "rustc-demangle"]
 
 #=======================================
 # Methods of serialization


### PR DESCRIPTION
Saves on ~40KB of code size if you don't need symbol demangling. Unfortunately, this would be a breaking change (because it changes the behavior of `--no-default-features`).

This came out of some size micro-optimizing in [signalapp/libsignal-client](/signalapp/libsignal-client)'s libsignal-jni package. We use [log-panics](https://docs.rs/log-panics/2.0.0/log_panics/), which pulls in backtrace, which pulls in addr2line, gimli, and rustc-demangle. It's possible we'll want to cut out using debug info altogether, in which case maybe we'd switch to something lighter like libunwind, but meanwhile skipping the demangling would still be a reasonable savings. `cargo bloat` unscientifically* suggests rustc-demangle contributes ~40 KB, with backtrace itself at ~100KB, addr2line at ~50KB, and gimli at ~30KB. Removing rustc-demangle isn't a *huge* win, but since it turned out to be this straightforward I figured I'd make the PR anyway. I'm not sure how to write automated tests for it, though.

\* because I'm running it on the built-for-host library, rather than the library we ship on Android.