### PR TITLE
make users able to set backtrace limit

### DIFF
--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -3,9 +3,9 @@ use core::fmt;
 use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering::SeqCst;
 
-#[cfg(all(target_os = "android", target_arch = "arm"))]
-const DEFAULT_TRACE_DEPTH_LIMIT: usize = usize::MAX;
 #[cfg(not(all(target_os = "android", target_arch = "arm")))]
+const DEFAULT_TRACE_DEPTH_LIMIT: usize = usize::MAX;
+#[cfg(all(target_os = "android", target_arch = "arm"))]
 const DEFAULT_TRACE_DEPTH_LIMIT: usize = 65535;
 static TRACE_DEPTH_LIMIT: AtomicUsize = AtomicUsize::new(DEFAULT_TRACE_DEPTH_LIMIT);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,9 @@ extern crate std;
 #[allow(unused_extern_crates)]
 extern crate alloc;
 
-pub use self::backtrace::{trace_unsynchronized, Frame};
+pub use self::backtrace::{
+    set_trace_depth_limit, get_trace_depth_limit, trace_unsynchronized, Frame,
+};
 mod backtrace;
 
 pub use self::symbolize::resolve_frame_unsynchronized;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ extern crate std;
 extern crate alloc;
 
 pub use self::backtrace::{
-    set_trace_depth_limit, get_trace_depth_limit, trace_unsynchronized, Frame,
+    get_trace_depth_limit, set_trace_depth_limit, trace_unsynchronized, Frame,
 };
 mod backtrace;
 


### PR DESCRIPTION
Recently I found a bug on android when I was attemping to capture stack backtrace in a rust function called by Android app through JNI. The `_Unwind_Backtrace` called our callback to push the `Frame`s into a `Vec` with the same address(`art_quick_generic_jni_trampoline + 42`) over and over again, and finally makes my device out of memory and have to kill the Android App to save the whole system. I think it's better to provide a api to make developers able to set the backtrace limit by themself, even when the backtrace is captured by third-party `crate`s.

Anyone can reproduce the problem using the following demo using an arm/aarch64 device with android 7.0 ~ android 12: 
https://github.com/name1e5s/backtrace_oom_demo