### PR TITLE
use rustup to install Miri

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -244,4 +244,4 @@ jobs:
         rustup toolchain install nightly --component miri
         rustup override set nightly
         cargo miri setup
-    - run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test
+    - run: MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-strict-provenance" cargo miri test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,6 +239,9 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: true
-    - name: Install Rust
-      run: ./ci/miri-rustup.sh
+    - name: Install Miri
+      run: |
+        rustup toolchain install nightly --component miri
+        rustup override set nightly
+        cargo miri setup
     - run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test

--- a/ci/miri-rustup.sh
+++ b/ci/miri-rustup.sh
@@ -1,7 +1,0 @@
-set -ex
-
-MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
-echo "Installing latest nightly with Miri: $MIRI_NIGHTLY"
-rustup set profile minimal
-rustup default "$MIRI_NIGHTLY"
-rustup component add miri


### PR DESCRIPTION
We no longer need to use `curl` and rely on https://rust-lang.github.io/rustup-components-history/.

Also crank up the Miri checks a bit while we are at it. ;)