### PR TITLE
Bump object to 0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ cpp_demangle = { default-features = false, version = "0.3.0", optional = true }
 # use these features directly.
 addr2line = { version = "0.17.0", default-features = false }
 miniz_oxide = { version = "0.5.0", default-features = false }
+
 [dependencies.object]
 version = "0.28.0"
 default-features = false

--- a/crates/as-if-std/Cargo.toml
+++ b/crates/as-if-std/Cargo.toml
@@ -19,7 +19,7 @@ addr2line = { version = "0.16.0", default-features = false, optional = true }
 miniz_oxide = { version = "0.4.0", default-features = false }
 
 [dependencies.object]
-version = "0.27"
+version = "0.28"
 default-features = false
 optional = true
 features = ['read_core', 'elf', 'macho', 'pe', 'unaligned', 'archive']


### PR DESCRIPTION
This bumps the object dependency to 0.28, so as to reduce the number of duplicated dependencies in upstream projects. Tests all passed locally.