### PR TITLE
Obey the return value from the trace visitor under Miri

### DIFF
--- a/src/backtrace/miri.rs
+++ b/src/backtrace/miri.rs
@@ -102,6 +102,8 @@ pub unsafe fn trace_unsynchronized<F: FnMut(&super::Frame) -> bool>(mut cb: F) {
 
     for ptr in frames.iter() {
         let frame = resolve_addr(*ptr as *mut c_void);
-        cb(&super::Frame { inner: frame });
+        if !cb(&super::Frame { inner: frame }) {
+            return;
+        }
     }
 }


### PR DESCRIPTION
We're supposed to stop visiting backtrace frames when the visitor returns `false`, but this used to just ignore the return value.

It's entirely possible that backtrace pruning has never worked under Miri due to this bug, and nobody noticed because the slowness in https://github.com/rust-lang/miri/issues/2273 which this bug contributes significantly to. Wonderfully circular.

cc @RalfJung 