### PR TITLE
Remove windows-i686-gnu CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,6 @@ jobs:
             rust: stable-i686-msvc
           - os: windows-latest
             rust: stable-x86_64-gnu
-          - os: windows-latest
-            rust: stable-i686-gnu
     steps:
     - uses: actions/checkout@v1
       with:


### PR DESCRIPTION
This is currently broken, as described in #479, and I'm not entirely
sure how to fix so to get things moving again this removes it from CI.