### PR TITLE
Bump miniz_oxide to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ cpp_demangle = { default-features = false, version = "0.3.0", optional = true }
 # Optional dependencies enabled through the `gimli-symbolize` feature, do not
 # use these features directly.
 addr2line = { version = "0.17.0", default-features = false }
-miniz_oxide = { version = "0.5.0", default-features = false }
+miniz_oxide = { version = "0.6.0", default-features = false }
 
 [dependencies.object]
 version = "0.29.0"


### PR DESCRIPTION
Should be released together with flate2 to avoid creating duplicate dependency versions in many projects.