### PR TITLE
Apply clippy::uninlined_format_args fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ fn main() {
 
     // do_some_work();
 
-    println!("{:?}", bt);
+    println!("{bt:?}");
 }
 ```
 

--- a/build.rs
+++ b/build.rs
@@ -29,8 +29,7 @@ fn build_android() {
         Ok(result) => result,
         Err(e) => {
             eprintln!(
-                "warning: android version detection failed while running C compiler: {}",
-                e
+                "warning: android version detection failed while running C compiler: {e}",
             );
             return;
         }
@@ -39,7 +38,7 @@ fn build_android() {
         Ok(s) => s,
         Err(_) => return,
     };
-    eprintln!("expanded android version detection:\n{}", expansion);
+    eprintln!("expanded android version detection:\n{expansion}");
     let i = match expansion.find(MARKER) {
         Some(i) => i,
         None => return,

--- a/build.rs
+++ b/build.rs
@@ -28,9 +28,7 @@ fn build_android() {
     let expansion = match cc::Build::new().file(&android_api_c).try_expand() {
         Ok(result) => result,
         Err(e) => {
-            eprintln!(
-                "warning: android version detection failed while running C compiler: {e}",
-            );
+            eprintln!("warning: android version detection failed while running C compiler: {e}");
             return;
         }
     };

--- a/crates/cpp_smoke_test/tests/smoke.rs
+++ b/crates/cpp_smoke_test/tests/smoke.rs
@@ -49,13 +49,13 @@ fn smoke_test_cpp() {
             .take(2)
             .collect();
 
-        println!("actual names = {:#?}", names);
+        println!("actual names = {names:#?}");
 
         let expected = [
             "void space::templated_trampoline<void (*)()>(void (*)())",
             "cpp_trampoline",
         ];
-        println!("expected names = {:#?}", expected);
+        println!("expected names = {expected:#?}");
 
         assert_eq!(names.len(), expected.len());
         for (actual, expected) in names.iter().zip(expected.iter()) {

--- a/crates/debuglink/src/main.rs
+++ b/crates/debuglink/src/main.rs
@@ -9,7 +9,7 @@ fn main() {
     let expect = std::path::Path::new(&crate_dir).join("src/main.rs");
 
     let bt = backtrace::Backtrace::new();
-    println!("{:?}", bt);
+    println!("{bt:?}");
 
     let mut found_main = false;
 
@@ -20,7 +20,7 @@ fn main() {
         }
 
         if let Some(name) = symbols[0].name() {
-            let name = format!("{:#}", name);
+            let name = format!("{name:#}");
             if name == "debuglink::main" {
                 found_main = true;
                 let filename = symbols[0].filename().unwrap();

--- a/crates/macos_frames_test/tests/main.rs
+++ b/crates/macos_frames_test/tests/main.rs
@@ -15,8 +15,7 @@ fn backtrace_no_dsym() {
     let executable_name = dsym_path.file_name().unwrap().to_str().unwrap().to_string();
     assert!(dsym_path.pop()); // Pop executable
     dsym_path.push(format!(
-        "{}.dSYM/Contents/Resources/DWARF/{0}",
-        executable_name
+        "{executable_name}.dSYM/Contents/Resources/DWARF/{executable_name}"
     ));
     let _ = fs::OpenOptions::new()
         .read(false)

--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -21,7 +21,7 @@ fn print() {
     let mut cnt = 0;
     backtrace::trace(|frame| {
         let ip = frame.ip();
-        print!("frame #{:<2} - {:#02$x}", cnt, ip as usize, HEX_WIDTH);
+        print!("frame #{cnt:<2} - {:#0HEX_WIDTH$x}", ip as usize);
         cnt += 1;
 
         let mut resolved = false;
@@ -33,13 +33,13 @@ fn print() {
             }
 
             if let Some(name) = symbol.name() {
-                print!(" - {}", name);
+                print!(" - {name}");
             } else {
                 print!(" - <unknown>");
             }
             if let Some(file) = symbol.filename() {
                 if let Some(l) = symbol.lineno() {
-                    print!("\n{:13}{:4$}@ {}:{}", "", "", file.display(), l, HEX_WIDTH);
+                    print!("\n{:13}{:HEX_WIDTH$}@ {}:{l}", "", "", file.display());
                 }
             }
             println!("");

--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -21,7 +21,7 @@ fn print() {
     let mut cnt = 0;
     backtrace::trace(|frame| {
         let ip = frame.ip();
-        print!("frame #{cnt:<2} - {:#0HEX_WIDTH$x}", ip as usize);
+        print!("frame #{:<2} - {:#02$x}", cnt, ip as usize, HEX_WIDTH);
         cnt += 1;
 
         let mut resolved = false;
@@ -39,7 +39,7 @@ fn print() {
             }
             if let Some(file) = symbol.filename() {
                 if let Some(l) = symbol.lineno() {
-                    print!("\n{:13}{:HEX_WIDTH$}@ {}:{l}", "", "", file.display());
+                    print!("\n{:13}{:4$}@ {}:{}", "", "", file.display(), l, HEX_WIDTH);
                 }
             }
             println!("");

--- a/src/capture.rs
+++ b/src/capture.rs
@@ -156,9 +156,9 @@ impl Backtrace {
     /// use backtrace::Backtrace;
     ///
     /// let mut current_backtrace = Backtrace::new_unresolved();
-    /// println!("{:?}", current_backtrace); // no symbol names
+    /// println!("{current_backtrace:?}"); // no symbol names
     /// current_backtrace.resolve();
-    /// println!("{:?}", current_backtrace); // symbol names now present
+    /// println!("{current_backtrace:?}"); // symbol names now present
     /// ```
     ///
     /// # Required features

--- a/src/print.rs
+++ b/src/print.rs
@@ -275,7 +275,7 @@ impl BacktraceFrameFmt<'_, '_, '_> {
         // Filename/line are printed on lines under the symbol name, so print
         // some appropriate whitespace to sort of right-align ourselves.
         if let PrintFmt::Full = self.fmt.format {
-            write!(self.fmt.fmt, "{:HEX_WIDTH$}", "")?;
+            write!(self.fmt.fmt, "{:1$}", "", HEX_WIDTH)?;
         }
         write!(self.fmt.fmt, "             at ")?;
 
@@ -297,7 +297,7 @@ impl BacktraceFrameFmt<'_, '_, '_> {
         // We only care about the first symbol of a frame
         if self.symbol_index == 0 {
             self.fmt.fmt.write_str("{{{bt:")?;
-            write!(self.fmt.fmt, "{}:{frame_ip:?}", self.fmt.frame_index)?;
+            write!(self.fmt.fmt, "{}:{:?}", self.fmt.frame_index, frame_ip)?;
             self.fmt.fmt.write_str("}}}\n")?;
         }
         Ok(())

--- a/src/print.rs
+++ b/src/print.rs
@@ -239,7 +239,7 @@ impl BacktraceFrameFmt<'_, '_, '_> {
         if self.symbol_index == 0 {
             write!(self.fmt.fmt, "{:4}: ", self.fmt.frame_index)?;
             if let PrintFmt::Full = self.fmt.format {
-                write!(self.fmt.fmt, "{:1$?} - ", frame_ip, HEX_WIDTH)?;
+                write!(self.fmt.fmt, "{frame_ip:HEX_WIDTH$?} - ")?;
             }
         } else {
             write!(self.fmt.fmt, "      ")?;
@@ -252,8 +252,8 @@ impl BacktraceFrameFmt<'_, '_, '_> {
         // more information if we're a full backtrace. Here we also handle
         // symbols which don't have a name,
         match (symbol_name, &self.fmt.format) {
-            (Some(name), PrintFmt::Short) => write!(self.fmt.fmt, "{:#}", name)?,
-            (Some(name), PrintFmt::Full) => write!(self.fmt.fmt, "{}", name)?,
+            (Some(name), PrintFmt::Short) => write!(self.fmt.fmt, "{name:#}")?,
+            (Some(name), PrintFmt::Full) => write!(self.fmt.fmt, "{name}")?,
             (None, _) | (_, PrintFmt::__Nonexhaustive) => write!(self.fmt.fmt, "<unknown>")?,
         }
         self.fmt.fmt.write_str("\n")?;
@@ -275,18 +275,18 @@ impl BacktraceFrameFmt<'_, '_, '_> {
         // Filename/line are printed on lines under the symbol name, so print
         // some appropriate whitespace to sort of right-align ourselves.
         if let PrintFmt::Full = self.fmt.format {
-            write!(self.fmt.fmt, "{:1$}", "", HEX_WIDTH)?;
+            write!(self.fmt.fmt, "{:HEX_WIDTH$}", "")?;
         }
         write!(self.fmt.fmt, "             at ")?;
 
         // Delegate to our internal callback to print the filename and then
         // print out the line number.
         (self.fmt.print_path)(self.fmt.fmt, file)?;
-        write!(self.fmt.fmt, ":{}", line)?;
+        write!(self.fmt.fmt, ":{line}")?;
 
         // Add column number, if available.
         if let Some(colno) = colno {
-            write!(self.fmt.fmt, ":{}", colno)?;
+            write!(self.fmt.fmt, ":{colno}")?;
         }
 
         write!(self.fmt.fmt, "\n")?;
@@ -297,7 +297,7 @@ impl BacktraceFrameFmt<'_, '_, '_> {
         // We only care about the first symbol of a frame
         if self.symbol_index == 0 {
             self.fmt.fmt.write_str("{{{bt:")?;
-            write!(self.fmt.fmt, "{}:{:?}", self.fmt.frame_index, frame_ip)?;
+            write!(self.fmt.fmt, "{}:{frame_ip:?}", self.fmt.frame_index)?;
             self.fmt.fmt.write_str("}}}\n")?;
         }
         Ok(())

--- a/src/print/fuchsia.rs
+++ b/src/print/fuchsia.rs
@@ -312,7 +312,7 @@ struct HexSlice<'a> {
 impl fmt::Display for HexSlice<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in self.bytes {
-            write!(f, "{:02x}", byte)?;
+            write!(f, "{byte:02x}")?;
         }
         Ok(())
     }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -421,7 +421,7 @@ cfg_if::cfg_if! {
                 // it outwards.
                 if let Some(ref cpp) = self.cpp_demangled.0 {
                     let mut s = String::new();
-                    if write!(s, "{}", cpp).is_ok() {
+                    if write!(s, "{cpp}").is_ok() {
                         return s.fmt(f)
                     }
                 }

--- a/tests/accuracy/main.rs
+++ b/tests/accuracy/main.rs
@@ -96,9 +96,9 @@ fn verify(filelines: &[Pos]) {
     println!("-----------------------------------");
     println!("looking for:");
     for (file, line) in filelines.iter().rev() {
-        println!("\t{}:{}", file, line);
+        println!("\t{file}:{line}");
     }
-    println!("found:\n{:?}", trace);
+    println!("found:\n{trace:?}");
     let mut symbols = trace.frames().iter().flat_map(|frame| frame.symbols());
     let mut iter = filelines.iter().rev();
     while let Some((file, line)) = iter.next() {

--- a/tests/current-exe-mismatch.rs
+++ b/tests/current-exe-mismatch.rs
@@ -20,7 +20,7 @@ fn main() {
                 println!("test result: ignored");
             }
             Err(EarlyExit::IoError(e)) => {
-                println!("{} parent encoutered IoError: {:?}", file!(), e);
+                println!("{} parent encountered IoError: {:?}", file!(), e);
                 panic!();
             }
         }
@@ -74,7 +74,7 @@ fn parent() -> Result<(), EarlyExit> {
 
 fn child() -> Result<(), EarlyExit> {
     let bt = backtrace::Backtrace::new();
-    println!("{:?}", bt);
+    println!("{bt:?}");
 
     let mut found_my_name = false;
 

--- a/tests/long_fn_name.rs
+++ b/tests/long_fn_name.rs
@@ -25,7 +25,7 @@ fn test_long_fn_name() {
     // It's actually longer since it also includes `::`, `<>` and the
     // name of the current module
     let bt = S::<S<S<S<S<S<S<S<S<S<i32>>>>>>>>>>::new();
-    println!("{:?}", bt);
+    println!("{bt:?}");
 
     let mut found_long_name_frame = false;
 

--- a/tests/skip_inner_frames.rs
+++ b/tests/skip_inner_frames.rs
@@ -18,7 +18,7 @@ fn backtrace_new_unresolved_should_start_with_call_site_trace() {
     }
     let mut b = Backtrace::new_unresolved();
     b.resolve();
-    println!("{:?}", b);
+    println!("{b:?}");
 
     assert!(!b.frames().is_empty());
 
@@ -34,7 +34,7 @@ fn backtrace_new_should_start_with_call_site_trace() {
         return;
     }
     let b = Backtrace::new();
-    println!("{:?}", b);
+    println!("{b:?}");
 
     assert!(!b.frames().is_empty());
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -111,16 +111,16 @@ fn smoke_test_frames() {
         backtrace::resolve_frame(frame, |sym| {
             print!("symbol  ip:{:?} address:{:?} ", frame.ip(), frame.symbol_address());
             if let Some(name) = sym.name() {
-                print!("name:{} ", name);
+                print!("name:{name} ");
             }
             if let Some(file) = sym.filename() {
                 print!("file:{} ", file.display());
             }
             if let Some(lineno) = sym.lineno() {
-                print!("lineno:{} ", lineno);
+                print!("lineno:{lineno} ");
             }
             if let Some(colno) = sym.colno() {
-                print!("colno:{} ", colno);
+                print!("colno:{colno} ");
             }
             println!();
         });
@@ -268,12 +268,12 @@ fn sp_smoke_test() {
 
         if refs.len() < 5 {
             recursive_stack_references(refs);
-            eprintln!("exiting: {}", x);
+            eprintln!("exiting: {x}");
             return;
         }
 
         backtrace::trace(make_trace_closure(refs));
-        eprintln!("exiting: {}", x);
+        eprintln!("exiting: {x}");
     }
 
     // NB: the following `make_*` functions are pulled out of line, rather than
@@ -295,7 +295,7 @@ fn sp_smoke_test() {
                     sym.name()
                         .and_then(|name| name.as_str())
                         .map_or(false, |name| {
-                            eprintln!("name = {}", name);
+                            eprintln!("name = {name}");
                             name.contains("recursive_stack_references")
                         })
             });


### PR DESCRIPTION
This is the result of running `clippy::uninlined_format_args` lint. Currently the lint is in `pedantic`, but there are plans/hopes to move it to `style`.

How can I add this specific lint to the current build/CI tools, or is this not possible?  It would be ideal not to make the lint as the default style and then end up with hundreds of changes in an unrelated PR due to CI requirements.

Locally, I ran this to generate the changes.  Not ideal because it has produced a number of compilation errors.

```bash
rustup run nightly cargo clippy --fix --no-deps --allow-dirty -- -A clippy::all -W clippy::uninlined_format_args
```

Note that the MSRV must be at least 1.58 (which introduced inline format args)