### PR TITLE
Change "OSX" to "macOS"

### DIFF
--- a/src/symbolize/gimli/macho.rs
+++ b/src/symbolize/gimli/macho.rs
@@ -13,8 +13,8 @@ type MachSection = <Mach as MachHeader>::Section;
 type MachNlist = <Mach as MachHeader>::Nlist;
 
 impl Mapping {
-    // The loading path for OSX is so different we just have a completely
-    // different implementation of the function here. On OSX we need to go
+    // The loading path for macOS is so different we just have a completely
+    // different implementation of the function here. On macOS we need to go
     // probing the filesystem for a bunch of files.
     pub fn new(path: &Path) -> Option<Mapping> {
         // First up we need to load the unique UUID which is stored in the macho

--- a/tests/skip_inner_frames.rs
+++ b/tests/skip_inner_frames.rs
@@ -4,7 +4,7 @@ use backtrace::Backtrace;
 // function for frames which reports the starting address of a symbol. As a
 // result it's only enabled on a few platforms.
 const ENABLED: bool = cfg!(all(
-    // Windows hasn't really been tested, and OSX doesn't support actually
+    // Windows hasn't really been tested, and macOS doesn't support actually
     // finding an enclosing frame, so disable this
     target_os = "linux",
     // On ARM finding the enclosing function is simply returning the ip itself.


### PR DESCRIPTION
Apple no longer uses the OS X branding.