### PR TITLE
C/C++ module file and line number are not looked up: addr2line 0.18.0 fixes it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ cpp_demangle = { default-features = false, version = "0.3.0", optional = true }
 
 # Optional dependencies enabled through the `gimli-symbolize` feature, do not
 # use these features directly.
-addr2line = { version = "0.17.0", default-features = false }
+addr2line = { version = "0.18.0", default-features = false }
 miniz_oxide = { version = "0.6.0", default-features = false }
 
 [dependencies.object]


### PR DESCRIPTION
OS: Linux

In a project with mixed C/C++ and Rust (e.g. embedding Rust in C/C++), `backtrace` does not correctly look up file and line numbers for symbols in C/C++ modules. Upgrading `addr2line` to 0.18.0 fixes it.

In a simple test project where C/C++ code calls the following Rust function
```rust
#[no_mangle]
pub extern "C" fn do_backtrace() {
    backtrace::trace(|frame| {
        backtrace::resolve_frame(frame, |symbol| {
            println!("{:?}", symbol);
        });

        true
    });
}
```

The results are:
```
Symbol { name: backtrace::backtrace::libunwind::trace::hc00fd2caa393a231, addr: 0x1be63c, filename: "/home/bart/dev/rust/backtrace-rs-fork/src/backtrace/libunwind.rs", lineno: 93 }
Symbol { name: backtrace::backtrace::trace_unsynchronized::h6193cc2c5c3617b2, addr: 0x1be63c, filename: "/home/bart/dev/rust/backtrace-rs-fork/src/backtrace/mod.rs", lineno: 66 }
Symbol { name: backtrace::backtrace::trace::he8dde40ef7a49457, addr: 0x1be776, filename: "/home/bart/dev/rust/backtrace-rs-fork/src/backtrace/mod.rs", lineno: 53 }
Symbol { name: "do_backtrace", addr: 0x3ddd5, filename: "/home/bart/dev/temp/zzz/rust_zzz/src/lib.rs", lineno: 8 }
Symbol { name: "_ZL10dump_stackb" }
Symbol { name: "_ZL16another_functionb" }
Symbol { name: "_ZL13some_functionb" }
Symbol { name: "main" }
Symbol { name: "__libc_start_main" }
Symbol { name: "_start", addr: 0x3dac4, filename: "/build/glibc/src/glibc/csu/../sysdeps/x86_64/start.S", lineno: 115 }
```

After upgrading `addr2line` version to 0.18.0, the results are correct:

```
Symbol { name: backtrace::backtrace::libunwind::trace::h0273b8e83debf323, addr: 0x2806ac, filename: "/home/bart/dev/rust/backtrace-rs-fork/src/backtrace/libunwind.rs", lineno: 93 }
Symbol { name: backtrace::backtrace::trace_unsynchronized::hfc31d3d1f9e4ee76, addr: 0x2806ac, filename: "/home/bart/dev/rust/backtrace-rs-fork/src/backtrace/mod.rs", lineno: 66 }
Symbol { name: backtrace::backtrace::trace::heabc35a113e1a579, addr: 0x2807e6, filename: "/home/bart/dev/rust/backtrace-rs-fork/src/backtrace/mod.rs", lineno: 53 }
Symbol { name: "do_backtrace", addr: 0x4add5, filename: "/home/bart/dev/temp/zzz/rust_zzz/src/lib.rs", lineno: 8 }
Symbol { name: "_ZL10dump_stackb", addr: 0x4acf4, filename: "/home/bart/dev/temp/zzz/src/main.cpp", lineno: 30 }
Symbol { name: "_ZL16another_functionb", addr: 0x4acac, filename: "/home/bart/dev/temp/zzz/src/main.cpp", lineno: 50 }
Symbol { name: "_ZL13some_functionb", addr: 0x4ac7c, filename: "/home/bart/dev/temp/zzz/src/main.cpp", lineno: 55 }
Symbol { name: "main", addr: 0x4abeb, filename: "/home/bart/dev/temp/zzz/src/main.cpp", lineno: 64 }
Symbol { name: "__libc_start_main" }
Symbol { name: "_start", addr: 0x4aac4, filename: "/build/glibc/src/glibc/csu/../sysdeps/x86_64/start.S", lineno: 115 }
```
