### PR TITLE
consider only elf text segments

### DIFF
--- a/src/symbolize/gimli/libs_dl_iterate_phdr.rs
+++ b/src/symbolize/gimli/libs_dl_iterate_phdr.rs
@@ -60,6 +60,9 @@ unsafe extern "C" fn callback(
         name,
         segments: headers
             .iter()
+            .filter(|header| {
+                (header.p_type & libc::PT_LOAD) != 0 && (header.p_flags & libc::PF_X) == libc::PF_X
+            })
             .map(|header| LibrarySegment {
                 len: (*header).p_memsz as usize,
                 stated_virtual_memory_address: (*header).p_vaddr as usize,


### PR DESCRIPTION
Question:

On Unix platforms (e.g. Linux),  `dl_iterate_phdr` is used to enumerate elf modules and their sections. These are then iterated upon in `gimli::avma_to_svma` to find the segment and calculate the address in order to look up DWARF debug data.

Is there are reason to consider any segments other than `.text`?

