### PR TITLE
Add API to support mapping cache capacity configurable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,8 +113,12 @@ extern crate alloc;
 pub use self::backtrace::{trace_unsynchronized, Frame};
 mod backtrace;
 
-pub use self::symbolize::{resolve_frame_unsynchronized, resolve_frame_unsynchronized_customized_cache};
-pub use self::symbolize::{resolve_unsynchronized, resolve_unsynchronized_customized_cache, Symbol, SymbolName};
+pub use self::symbolize::{
+    resolve_frame_unsynchronized, resolve_frame_unsynchronized_customized_cache,
+};
+pub use self::symbolize::{
+    resolve_unsynchronized, resolve_unsynchronized_customized_cache, Symbol, SymbolName,
+};
 mod symbolize;
 
 pub use self::types::BytesOrWideString;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,8 +113,8 @@ extern crate alloc;
 pub use self::backtrace::{trace_unsynchronized, Frame};
 mod backtrace;
 
-pub use self::symbolize::resolve_frame_unsynchronized;
-pub use self::symbolize::{resolve_unsynchronized, Symbol, SymbolName};
+pub use self::symbolize::{resolve_frame_unsynchronized, resolve_frame_unsynchronized_customized_cache};
+pub use self::symbolize::{resolve_unsynchronized, resolve_unsynchronized_customized_cache, Symbol, SymbolName};
 mod symbolize;
 
 pub use self::types::BytesOrWideString;
@@ -129,7 +129,7 @@ pub use print::{BacktraceFmt, BacktraceFrameFmt, PrintFmt};
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {
         pub use self::backtrace::trace;
-        pub use self::symbolize::{resolve, resolve_frame};
+        pub use self::symbolize::{resolve, resolve_customized_cache, resolve_frame, resolve_frame_customized_cache};
         pub use self::capture::{Backtrace, BacktraceFrame, BacktraceSymbol};
         mod capture;
     }

--- a/src/symbolize/dbghelp.rs
+++ b/src/symbolize/dbghelp.rs
@@ -71,7 +71,11 @@ impl Symbol<'_> {
 #[repr(C, align(8))]
 struct Aligned8<T>(T);
 
-pub unsafe fn resolve(what: ResolveWhat<'_>, cb: &mut dyn FnMut(&super::Symbol)) {
+pub unsafe fn resolve(
+    what: ResolveWhat<'_>,
+    _cache_capacity: usize,
+    cb: &mut dyn FnMut(&super::Symbol),
+) {
     // Ensure this process's symbols are initialized
     let dbghelp = match dbghelp::init() {
         Ok(dbghelp) => dbghelp,

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -238,7 +238,9 @@ struct LibrarySegment {
 
 // unsafe because this is required to be externally synchronized
 pub unsafe fn clear_symbol_cache() {
-    Cache::with_global(super::DEFAULT_MAPPINGS_CACHE_SIZE, |cache| cache.mappings.clear());
+    Cache::with_global(super::DEFAULT_MAPPINGS_CACHE_SIZE, |cache| {
+        cache.mappings.clear()
+    });
 }
 
 impl Cache {
@@ -300,7 +302,11 @@ impl Cache {
             .next()
     }
 
-    fn mapping_for_lib<'a>(&'a mut self, lib: usize, cache_capacity: usize) -> Option<&'a mut Context<'a>> {
+    fn mapping_for_lib<'a>(
+        &'a mut self,
+        lib: usize,
+        cache_capacity: usize,
+    ) -> Option<&'a mut Context<'a>> {
         let idx = self.mappings.iter().position(|(idx, _)| *idx == lib);
 
         // Invariant: after this conditional completes without early returning
@@ -333,7 +339,11 @@ impl Cache {
     }
 }
 
-pub unsafe fn resolve(what: ResolveWhat<'_>, cache_capacity: usize, cb: &mut dyn FnMut(&super::Symbol)) {
+pub unsafe fn resolve(
+    what: ResolveWhat<'_>,
+    cache_capacity: usize,
+    cb: &mut dyn FnMut(&super::Symbol),
+) {
     let addr = what.address_or_ip();
     let mut call = |sym: Symbol<'_>| {
         // Extend the lifetime of `sym` to `'static` since we are unfortunately

--- a/src/symbolize/miri.rs
+++ b/src/symbolize/miri.rs
@@ -5,7 +5,11 @@ use super::super::backtrace::miri::{resolve_addr, Frame};
 use super::BytesOrWideString;
 use super::{ResolveWhat, SymbolName};
 
-pub unsafe fn resolve(what: ResolveWhat<'_>, cb: &mut dyn FnMut(&super::Symbol)) {
+pub unsafe fn resolve(
+    what: ResolveWhat<'_>,
+    _cache_capacity: usize,
+    cb: &mut dyn FnMut(&super::Symbol),
+) {
     let sym = match what {
         ResolveWhat::Address(addr) => Symbol {
             inner: resolve_addr(addr),

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -62,6 +62,12 @@ pub fn resolve<F: FnMut(&Symbol)>(addr: *mut c_void, cb: F) {
     let _guard = crate::lock::lock();
     unsafe { resolve_unsynchronized(addr, cb) }
 }
+/// Same as `resolve`, but the user can specified the shared libraries mapping cache capacity.
+#[cfg(feature = "std")]
+pub fn resolve_customized_cache<F: FnMut(&Symbol)>(cache_capacity: usize, addr: *mut c_void, cb: F) {
+    let _guard = crate::lock::lock();
+    unsafe { resolve_unsynchronized_customized_cache(addr, cache_capacity, cb) }
+}
 
 /// Resolve a previously capture frame to a symbol, passing the symbol to the
 /// specified closure.
@@ -105,6 +111,13 @@ pub fn resolve_frame<F: FnMut(&Symbol)>(frame: &Frame, cb: F) {
     unsafe { resolve_frame_unsynchronized(frame, cb) }
 }
 
+/// Same as `resolve_frame`, but the user can specified the shared libraries mapping cache capacity.
+#[cfg(feature = "std")]
+pub fn resolve_frame_customized_cache<F: FnMut(&Symbol)>(frame: &Frame, cb: F, cache_capacity: usize) {
+    let _guard = crate::lock::lock();
+    unsafe { resolve_frame_unsynchronized_customized_cache(frame, cache_capacity, cb) }
+}
+
 pub enum ResolveWhat<'a> {
     Address(*mut c_void),
     Frame(&'a Frame),
@@ -146,6 +159,8 @@ fn adjust_ip(a: *mut c_void) -> *mut c_void {
     }
 }
 
+const DEFAULT_MAPPINGS_CACHE_SIZE: usize = 4;
+
 /// Same as `resolve`, only unsafe as it's unsynchronized.
 ///
 /// This function does not have synchronization guarantees but is available when
@@ -159,7 +174,14 @@ pub unsafe fn resolve_unsynchronized<F>(addr: *mut c_void, mut cb: F)
 where
     F: FnMut(&Symbol),
 {
-    imp::resolve(ResolveWhat::Address(addr), &mut cb)
+    imp::resolve(ResolveWhat::Address(addr), DEFAULT_MAPPINGS_CACHE_SIZE, &mut cb)
+}
+/// Same as `resolve_unsynchronized`, but the user can specified the shared libraries mapping cache capacity.
+pub unsafe fn resolve_unsynchronized_customized_cache<F>(addr: *mut c_void, cache_capacity: usize, mut cb: F)
+where
+    F: FnMut(&Symbol),
+{
+    imp::resolve(ResolveWhat::Address(addr), cache_capacity, &mut cb)
 }
 
 /// Same as `resolve_frame`, only unsafe as it's unsynchronized.
@@ -175,7 +197,15 @@ pub unsafe fn resolve_frame_unsynchronized<F>(frame: &Frame, mut cb: F)
 where
     F: FnMut(&Symbol),
 {
-    imp::resolve(ResolveWhat::Frame(frame), &mut cb)
+    imp::resolve(ResolveWhat::Frame(frame), DEFAULT_MAPPINGS_CACHE_SIZE, &mut cb)
+}
+
+/// Same as `resolve_frame_unsynchronized`, but the user can specified the shared libraries mapping cache capacity.
+pub unsafe fn resolve_frame_unsynchronized_customized_cache<F>(frame: &Frame, cache_capacity: usize, mut cb: F)
+where
+    F: FnMut(&Symbol),
+{
+    imp::resolve(ResolveWhat::Frame(frame), cache_capacity, &mut cb)
 }
 
 /// A trait representing the resolution of a symbol in a file.

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -64,7 +64,11 @@ pub fn resolve<F: FnMut(&Symbol)>(addr: *mut c_void, cb: F) {
 }
 /// Same as `resolve`, but the user can specified the shared libraries mapping cache capacity.
 #[cfg(feature = "std")]
-pub fn resolve_customized_cache<F: FnMut(&Symbol)>(cache_capacity: usize, addr: *mut c_void, cb: F) {
+pub fn resolve_customized_cache<F: FnMut(&Symbol)>(
+    cache_capacity: usize,
+    addr: *mut c_void,
+    cb: F,
+) {
     let _guard = crate::lock::lock();
     unsafe { resolve_unsynchronized_customized_cache(addr, cache_capacity, cb) }
 }
@@ -113,7 +117,11 @@ pub fn resolve_frame<F: FnMut(&Symbol)>(frame: &Frame, cb: F) {
 
 /// Same as `resolve_frame`, but the user can specified the shared libraries mapping cache capacity.
 #[cfg(feature = "std")]
-pub fn resolve_frame_customized_cache<F: FnMut(&Symbol)>(frame: &Frame, cb: F, cache_capacity: usize) {
+pub fn resolve_frame_customized_cache<F: FnMut(&Symbol)>(
+    frame: &Frame,
+    cb: F,
+    cache_capacity: usize,
+) {
     let _guard = crate::lock::lock();
     unsafe { resolve_frame_unsynchronized_customized_cache(frame, cache_capacity, cb) }
 }
@@ -174,11 +182,18 @@ pub unsafe fn resolve_unsynchronized<F>(addr: *mut c_void, mut cb: F)
 where
     F: FnMut(&Symbol),
 {
-    imp::resolve(ResolveWhat::Address(addr), DEFAULT_MAPPINGS_CACHE_SIZE, &mut cb)
+    imp::resolve(
+        ResolveWhat::Address(addr),
+        DEFAULT_MAPPINGS_CACHE_SIZE,
+        &mut cb,
+    )
 }
 /// Same as `resolve_unsynchronized`, but the user can specified the shared libraries mapping cache capacity.
-pub unsafe fn resolve_unsynchronized_customized_cache<F>(addr: *mut c_void, cache_capacity: usize, mut cb: F)
-where
+pub unsafe fn resolve_unsynchronized_customized_cache<F>(
+    addr: *mut c_void,
+    cache_capacity: usize,
+    mut cb: F,
+) where
     F: FnMut(&Symbol),
 {
     imp::resolve(ResolveWhat::Address(addr), cache_capacity, &mut cb)
@@ -197,12 +212,19 @@ pub unsafe fn resolve_frame_unsynchronized<F>(frame: &Frame, mut cb: F)
 where
     F: FnMut(&Symbol),
 {
-    imp::resolve(ResolveWhat::Frame(frame), DEFAULT_MAPPINGS_CACHE_SIZE, &mut cb)
+    imp::resolve(
+        ResolveWhat::Frame(frame),
+        DEFAULT_MAPPINGS_CACHE_SIZE,
+        &mut cb,
+    )
 }
 
 /// Same as `resolve_frame_unsynchronized`, but the user can specified the shared libraries mapping cache capacity.
-pub unsafe fn resolve_frame_unsynchronized_customized_cache<F>(frame: &Frame, cache_capacity: usize, mut cb: F)
-where
+pub unsafe fn resolve_frame_unsynchronized_customized_cache<F>(
+    frame: &Frame,
+    cache_capacity: usize,
+    mut cb: F,
+) where
     F: FnMut(&Symbol),
 {
     imp::resolve(ResolveWhat::Frame(frame), cache_capacity, &mut cb)

--- a/src/symbolize/noop.rs
+++ b/src/symbolize/noop.rs
@@ -5,7 +5,12 @@ use super::{BytesOrWideString, ResolveWhat, SymbolName};
 use core::ffi::c_void;
 use core::marker;
 
-pub unsafe fn resolve(_addr: ResolveWhat<'_>, _cb: &mut dyn FnMut(&super::Symbol)) {}
+pub unsafe fn resolve(
+    _addr: ResolveWhat<'_>,
+    _cache_capacity: usize,
+    _cb: &mut dyn FnMut(&super::Symbol),
+) {
+}
 
 pub struct Symbol<'a> {
     _marker: marker::PhantomData<&'a i32>,


### PR DESCRIPTION
Signed-off-by: hehechen <awd123456sss@gmail.com>
closes: https://github.com/rust-lang/backtrace-rs/issues/499

In some scenarios, users may want to increase [MAPPINGS_CACHE_SIZE](https://github.com/rust-lang/backtrace-rs/blob/5be2e8ba9cf6e391c5fa45219fc091b4075eb6be/src/symbolize/gimli.rs#L55) to trade memory for performance improvement. 
This PR add some functions:
`resolve_frame_customized_cache`
`resolve_frame_unsynchronized_customized_cache`
`resolve_customized_cache`
`resolve_unsynchronized_customized_cache`
So that users can modify cache capacity to improve performance.
