### PR TITLE
Add symbolize support for qnx-nto

### DIFF
--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -41,6 +41,7 @@ cfg_if::cfg_if! {
         target_os = "openbsd",
         target_os = "solaris",
         target_os = "illumos",
+        target_os = "nto",
     ))] {
         #[path = "gimli/mmap_unix.rs"]
         mod mmap;
@@ -178,6 +179,7 @@ cfg_if::cfg_if! {
             target_os = "fuchsia",
             target_os = "freebsd",
             target_os = "openbsd",
+            target_os = "nto",
             all(target_os = "android", feature = "dl_iterate_phdr"),
         ),
         not(target_env = "uclibc"),


### PR DESCRIPTION
This enables symbol resolution on the QNX nto operating system.

These `cfg`s require the following symbols/definitions from `libc` which exist for the target:
- [`mmap`](https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.lib_ref/topic/m/mmap.html)
- [`munmap`](https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.lib_ref/topic/m/munmap.html)
	- `MAP_FAILED`
	- `PROT_READ`
	- `MAP_PRIVATE`
- [`dl_iterate_phdr`](
https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.lib_ref/topic/d/dl_iterate_phdr.html)
	- `dl_phdr_info`
- `size_t`
- `c_void`
- `c_int`

We are currently doing a port of this for ferrocene and since backtrace-rs is a submodule in `rust-lang/rust`, having this addition upstreamed would save us from manually maintaining a fork for these two changes.