### PR TITLE
(Temporarily?) Disable CI builds for `x86_64-fuchsia`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -204,9 +204,9 @@ jobs:
         target:
         - wasm32-unknown-unknown
         - wasm32-wasi
-        - x86_64-fuchsia
         - x86_64-fortanix-unknown-sgx
         - x86_64-unknown-illumos
+        # - x86_64-fuchsia # error: toolchain 'nightly-x86_64-unknown-linux-gnu' does not contain component 'rust-std' for target 'x86_64-fuchsia'
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
CI fails because there is no std lib available:
```
error: toolchain 'nightly-x86_64-unknown-linux-gnu' does not contain component 'rust-std' for target 'x86_64-fuchsia'
```
  Availability monitor: https://rust-lang.github.io/rustup-components-history/