### PR TITLE
allow an offset of 1 in the accuracy of line numbers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -204,9 +204,9 @@ jobs:
         target:
         - wasm32-unknown-unknown
         - wasm32-wasi
-        - x86_64-fuchsia
         - x86_64-fortanix-unknown-sgx
         - x86_64-unknown-illumos
+        # - x86_64-fuchsia # error: toolchain 'nightly-x86_64-unknown-linux-gnu' does not contain component 'rust-std' for target 'x86_64-fuchsia'
     steps:
     - uses: actions/checkout@v3
       with:

--- a/tests/accuracy/main.rs
+++ b/tests/accuracy/main.rs
@@ -107,7 +107,8 @@ fn verify(filelines: &[Pos]) {
             };
             if let Some(filename) = sym.filename() {
                 if let Some(lineno) = sym.lineno() {
-                    if filename.ends_with(file) && lineno == *line {
+                    // allow an offset of 1 in the accuracy of line numbers
+                    if filename.ends_with(file) && lineno.abs_diff(*line) <= 1 {
                         break;
                     }
                 }


### PR DESCRIPTION
As the documentation says, line numbers cannot be determined with 100% accuracy.