### PR TITLE
Add other apple targets to libunwind workaround

### DIFF
--- a/src/backtrace/libunwind.rs
+++ b/src/backtrace/libunwind.rs
@@ -66,7 +66,11 @@ impl Frame {
         //
         // Note the `skip_inner_frames.rs` test is skipped on macOS due to this
         // clause, and if this is fixed that test in theory can be run on macOS!
-        if cfg!(target_os = "macos") || cfg!(target_os = "ios") {
+        if cfg!(target_os = "macos")
+            || cfg!(target_os = "ios")
+            || cfg!(target_os = "tvos")
+            || cfg!(target_os = "watchos")
+        {
             self.ip()
         } else {
             unsafe { uw::_Unwind_FindEnclosingFunction(self.ip()) }

--- a/src/backtrace/libunwind.rs
+++ b/src/backtrace/libunwind.rs
@@ -66,11 +66,7 @@ impl Frame {
         //
         // Note the `skip_inner_frames.rs` test is skipped on macOS due to this
         // clause, and if this is fixed that test in theory can be run on macOS!
-        if cfg!(target_os = "macos")
-            || cfg!(target_os = "ios")
-            || cfg!(target_os = "tvos")
-            || cfg!(target_os = "watchos")
-        {
+        if cfg!(target_vendor = "apple") {
             self.ip()
         } else {
             unsafe { uw::_Unwind_FindEnclosingFunction(self.ip()) }


### PR DESCRIPTION
Having done some reading, I'm pretty sure this is needed on the other apple targets as well, just nobody has tested it.

Unfortunately, I'm unsure how to test this reliably though, since I haven't exactly seen the issue (`_Unwind_FindEnclosingFunction` has been reliable for me, although I believe this is a non-deterministic issue, so I dunno how much that means).