### PR TITLE
Don't fail-fast on `Test` workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-20.04
@@ -156,6 +157,7 @@ jobs:
     name: Docker
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         target:
         - aarch64-unknown-linux-gnu


### PR DESCRIPTION
This at least allows testing all platforms regardless of platform-specific failures.