### PR TITLE
deps: update miniz_oxide to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ rustc-serialize = { version = "0.3", optional = true }
 cpp_demangle = { default-features = false, version = "0.4.0", optional = true, features = ["alloc"] }
 
 addr2line = { version = "0.20.0", default-features = false }
-miniz_oxide = { version = "0.6.0", default-features = false }
+miniz_oxide = { version = "0.7.0", default-features = false }
 
 [dependencies.object]
 version = "0.30.0"


### PR DESCRIPTION
I don't think this change the MSRV but I haven't really checked.

Could a new release be done with this too ?