### PR TITLE
bump miniz_oxide to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ rustc-serialize = { version = "0.3", optional = true }
 cpp_demangle = { default-features = false, version = "0.4.0", optional = true, features = ["alloc"] }
 
 addr2line = { version = "0.19.0", default-features = false }
-miniz_oxide = { version = "0.6.0", default-features = false }
+miniz_oxide = { version = "0.7.0", default-features = false }
 
 [dependencies.object]
 version = "0.30.0"


### PR DESCRIPTION
`flate2` bumped it  https://github.com/rust-lang/flate2-rs/issues/340