### PR TITLE
Add an exception for QNX Neutrino 7.0 as a 'no-op' platform

### DIFF
--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -138,6 +138,7 @@ cfg_if::cfg_if! {
                 unix,
                 not(target_os = "emscripten"),
                 not(all(target_os = "ios", target_arch = "arm")),
+                not(all(target_os = "nto", target_env = "nto70")),
             ),
             all(
                 target_env = "sgx",


### PR DESCRIPTION
The QNX Neutrino 7.0 target ships a toolchain without a native unwinder implementation. libgcc with unwinding symbols is present in version 7.1 and newer, which is why 7.0 is the only version called out here.