### PR TITLE
Update CI script to handle newer versions of the Android NDK

### DIFF
--- a/ci/android-ndk.sh
+++ b/ci/android-ndk.sh
@@ -1,23 +1,14 @@
 set -ex
 
-ANDROID_ARCH=$1
-ANDROID_SDK_VERSION=4333796
+ANDROID_NDK_URL=https://dl.google.com/android/repository
+ANDROID_NDK_ARCHIVE=android-ndk-r25b-linux.zip
 
-mkdir /tmp/android
-cd /tmp/android
-
-curl -o android-sdk.zip \
-  "https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_VERSION}.zip"
-unzip -q android-sdk.zip
-
-yes | ./tools/bin/sdkmanager --licenses > /dev/null
-./tools/bin/sdkmanager ndk-bundle > /dev/null
-
-./ndk-bundle/build/tools/make_standalone_toolchain.py \
-  --arch $ANDROID_ARCH \
-  --stl=libc++ \
-  --api 21 \
-  --install-dir /android-toolchain
+mkdir /android-toolchain
+cd /android-toolchain
+curl -fO $ANDROID_NDK_URL/$ANDROID_NDK_ARCHIVE
+unzip -q $ANDROID_NDK_ARCHIVE
+rm $ANDROID_NDK_ARCHIVE
+mv android-ndk-* ndk
 
 cd /tmp
 rm -rf android

--- a/ci/docker/aarch64-linux-android/Dockerfile
+++ b/ci/docker/aarch64-linux-android/Dockerfile
@@ -10,9 +10,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libc6-dev
 
 COPY android-ndk.sh /
-RUN /android-ndk.sh arm64
-ENV PATH=$PATH:/android-toolchain/bin
+RUN /android-ndk.sh
+ENV PATH=$PATH:/android-toolchain/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin
 
 # TODO: run tests in an emulator eventually
-ENV CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android-gcc \
+ENV CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android21-clang \
     CARGO_TARGET_AARCH64_LINUX_ANDROID_RUNNER=echo

--- a/ci/docker/arm-linux-androideabi/Dockerfile
+++ b/ci/docker/arm-linux-androideabi/Dockerfile
@@ -10,9 +10,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libc6-dev
 
 COPY android-ndk.sh /
-RUN /android-ndk.sh arm
-ENV PATH=$PATH:/android-toolchain/bin
+RUN /android-ndk.sh
+ENV PATH=$PATH:/android-toolchain/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin
 
 # TODO: run tests in an emulator eventually
-ENV CARGO_TARGET_ARM_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc \
+ENV CARGO_TARGET_ARM_LINUX_ANDROIDEABI_LINKER=armv7a-linux-androideabi19-clang \
     CARGO_TARGET_ARM_LINUX_ANDROIDEABI_RUNNER=echo

--- a/ci/docker/armv7-linux-androideabi/Dockerfile
+++ b/ci/docker/armv7-linux-androideabi/Dockerfile
@@ -10,9 +10,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libc6-dev
 
 COPY android-ndk.sh /
-RUN /android-ndk.sh arm
-ENV PATH=$PATH:/android-toolchain/bin
+RUN /android-ndk.sh
+ENV PATH=$PATH:/android-toolchain/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin
 
 # TODO: run tests in an emulator eventually
-ENV CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc \
+ENV CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=armv7a-linux-androideabi19-clang \
     CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_RUNNER=echo

--- a/ci/docker/i686-linux-android/Dockerfile
+++ b/ci/docker/i686-linux-android/Dockerfile
@@ -10,9 +10,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libc6-dev
 
 COPY android-ndk.sh /
-RUN /android-ndk.sh x86
-ENV PATH=$PATH:/android-toolchain/bin
+RUN /android-ndk.sh
+ENV PATH=$PATH:/android-toolchain/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin
 
 # TODO: run tests in an emulator eventually
-ENV CARGO_TARGET_I686_LINUX_ANDROID_LINKER=i686-linux-android-gcc \
+ENV CARGO_TARGET_I686_LINUX_ANDROID_LINKER=i686-linux-android19-clang \
     CARGO_TARGET_I686_LINUX_ANDROID_RUNNER=echo

--- a/ci/docker/x86_64-linux-android/Dockerfile
+++ b/ci/docker/x86_64-linux-android/Dockerfile
@@ -10,9 +10,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libc6-dev
 
 COPY android-ndk.sh /
-RUN /android-ndk.sh x86_64
-ENV PATH=$PATH:/android-toolchain/bin
+RUN /android-ndk.sh
+ENV PATH=$PATH:/android-toolchain/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin
 
 # TODO: run tests in an emulator eventually
-ENV CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=x86_64-linux-android-gcc \
+ENV CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=x86_64-linux-android21-clang \
     CARGO_TARGET_X86_64_LINUX_ANDROID_RUNNER=echo


### PR DESCRIPTION
The NDK is now structured such that the `make_standalone_toolchain.py` step is no longer required.  The NDK can simply be unpacked and used as-is.