### PR TITLE
Upgrade to 2021 ed and inline panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ A library to acquire a stack trace (backtrace) at runtime in a Rust program.
 """
 autoexamples = true
 autotests = true
-edition = "2018"
+edition = "2021"
 exclude = ["/ci/"]
 
 [workspace]
@@ -118,12 +118,12 @@ required-features = ["std"]
 [[test]]
 name = "smoke"
 required-features = ["std"]
-edition = '2018'
+edition = '2021'
 
 [[test]]
 name = "accuracy"
 required-features = ["std"]
-edition = '2018'
+edition = '2021'
 
 [[test]]
 name = "concurrent-panics"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ autoexamples = true
 autotests = true
 edition = "2021"
 exclude = ["/ci/"]
+rust-version = "1.65.0"
 
 [workspace]
 members = ['crates/cpp_smoke_test', 'crates/as-if-std']

--- a/crates/as-if-std/Cargo.toml
+++ b/crates/as-if-std/Cargo.toml
@@ -2,7 +2,7 @@
 name = "as-if-std"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/debuglink/Cargo.toml
+++ b/crates/debuglink/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "debuglink"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 backtrace = { path = "../.." }

--- a/crates/dylib-dep/Cargo.toml
+++ b/crates/dylib-dep/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dylib-dep"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 authors = []
 publish = false
 

--- a/crates/line-tables-only/Cargo.toml
+++ b/crates/line-tables-only/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "line-tables-only"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [build-dependencies]
 cc = "1.0"

--- a/crates/line-tables-only/src/lib.rs
+++ b/crates/line-tables-only/src/lib.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
     use backtrace::Backtrace;
     use libc::c_void;
+    use std::path::Path;
 
     pub type Callback = extern "C" fn(data: *mut c_void);
 
@@ -15,11 +15,12 @@ mod tests {
         unsafe { *(data as *mut Option<Backtrace>) = Some(bt) };
     }
 
-    fn assert_contains(backtrace: &Backtrace,
-                       expected_name: &str,
-                       expected_file: &str,
-                       expected_line: u32) {
-
+    fn assert_contains(
+        backtrace: &Backtrace,
+        expected_name: &str,
+        expected_file: &str,
+        expected_line: u32,
+    ) {
         let expected_file = Path::new(expected_file);
 
         for frame in backtrace.frames() {
@@ -34,7 +35,7 @@ mod tests {
             }
         }
 
-        panic!("symbol {:?} not found in backtrace: {:?}", expected_name, backtrace);
+        panic!("symbol {expected_name:?} not found in backtrace: {backtrace:?}");
     }
 
     /// Verifies that when debug info includes only lines tables the generated

--- a/crates/macos_frames_test/Cargo.toml
+++ b/crates/macos_frames_test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "macos_frames_test"
 version = "0.1.0"
 authors = ["Aaron Hill <aa1ronham@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies.backtrace]
 path = "../.."

--- a/crates/without_debuginfo/Cargo.toml
+++ b/crates/without_debuginfo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "without_debuginfo"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies.backtrace]
 path = "../.."

--- a/tests/accuracy/main.rs
+++ b/tests/accuracy/main.rs
@@ -103,7 +103,7 @@ fn verify(filelines: &[Pos]) {
         loop {
             let sym = match symbols.next() {
                 Some(sym) => sym,
-                None => panic!("failed to find {}:{}", file, line),
+                None => panic!("failed to find {file}:{line}"),
             };
             if let Some(filename) = sym.filename() {
                 if let Some(lineno) = sym.lineno() {

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -150,9 +150,7 @@ fn smoke_test_frames() {
         if cfg!(debug_assertions) {
             assert!(
                 name.contains(expected_name),
-                "didn't find `{}` in `{}`",
-                expected_name,
-                name
+                "didn't find `{expected_name}` in `{name}`"
             );
         }
 
@@ -164,18 +162,13 @@ fn smoke_test_frames() {
             if !expected_file.is_empty() {
                 assert!(
                     file.ends_with(expected_file),
-                    "{:?} didn't end with {:?}",
-                    file,
-                    expected_file
+                    "{file:?} didn't end with {expected_file:?}"
                 );
             }
             if expected_line != 0 {
                 assert!(
                     line == expected_line,
-                    "bad line number on frame for `{}`: {} != {}",
-                    expected_name,
-                    line,
-                    expected_line
+                    "bad line number on frame for `{expected_name}`: {line} != {expected_line}"
                 );
             }
 
@@ -185,10 +178,7 @@ fn smoke_test_frames() {
                 if expected_col != 0 {
                     assert!(
                         col == expected_col,
-                        "bad column number on frame for `{}`: {} != {}",
-                        expected_name,
-                        col,
-                        expected_col
+                        "bad column number on frame for `{expected_name}`: {col} != {expected_col}",
                     );
                 }
             }


### PR DESCRIPTION
Panics and asserts do not work the same way with inlined format args, so this updates all crates to 2021 edition.

This PR complements #486, but is independent of it

Note that just like #486, the MSRV must be at least 1.58 (which introduced inline format args)