### PR TITLE
reduce dependencies for windows-msvc targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ exclude = [
 [dependencies]
 cfg-if = "1.0"
 rustc-demangle = "0.1.4"
-libc = { version = "0.2.146", default-features = false }
 
 # Optionally enable the ability to serialize a `Backtrace`, controlled through
 # the `serialize-*` features below.
@@ -38,10 +37,12 @@ rustc-serialize = { version = "0.3", optional = true }
 # Optionally demangle C++ frames' symbols in backtraces.
 cpp_demangle = { default-features = false, version = "0.4.0", optional = true, features = ["alloc"] }
 
-addr2line = { version = "0.21.0", default-features = false }
+[target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
 miniz_oxide = { version = "0.7.0", default-features = false }
+addr2line = { version = "0.21.0", default-features = false }
+libc = { version = "0.2.146", default-features = false }
 
-[dependencies.object]
+[target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies.object]
 version = "0.32.0"
 default-features = false
 features = ['read_core', 'elf', 'macho', 'pe', 'unaligned', 'archive']

--- a/crates/as-if-std/Cargo.toml
+++ b/crates/as-if-std/Cargo.toml
@@ -15,10 +15,12 @@ bench = false
 cfg-if = "1.0"
 rustc-demangle = "0.1.21"
 libc = { version = "0.2.146", default-features = false }
-addr2line = { version = "0.21.0", default-features = false, optional = true }
-miniz_oxide = { version = "0.7", default-features = false }
 
-[dependencies.object]
+[target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
+miniz_oxide = { version = "0.7.0", optional = true, default-features = false }
+addr2line = { version = "0.21.0", optional = true, default-features = false }
+
+[target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies.object]
 version = "0.32.0"
 default-features = false
 optional = true
@@ -30,4 +32,4 @@ cc = "1.0.67"
 
 [features]
 default = ['backtrace']
-backtrace = ['addr2line', 'object']
+backtrace = ['addr2line', 'miniz_oxide', 'object']

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -471,7 +471,7 @@ cfg_if::cfg_if! {
         mod dbghelp;
         use dbghelp as imp;
     } else if #[cfg(all(
-        any(unix, windows),
+        any(unix, all(windows, target_env = "gnu")),
         not(target_vendor = "uwp"),
         not(target_os = "emscripten"),
         any(not(backtrace_in_libstd), feature = "backtrace"),


### PR DESCRIPTION
Some dependencies don't used on windows-msvc targets, so exclude them:
* `miniz_oxide` (+ `adler`) 
* `addr2line` (+ `gimli`)
* `object` (+ `memchr`)
* `libc` too


Will sync with rust repo