### PR TITLE
CI: fix fetch of PR fork commits in binary size check workflow

### DIFF
--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           printf "[llvm]\ndownload-ci-llvm = true\n\n[rust]\nincremental = false\n" > config.toml
           cd library/backtrace
-          git remote add kobzol https://github.com/kobzol/backtrace-rs
+          git remote add head-pr https://github.com/${{ github.event.pull_request.head.repo.full_name }}
           git fetch --all
           git checkout ${{ github.event.pull_request.base.sha }}
           cd ../..


### PR DESCRIPTION
Probably not all PRs to this repo will come from *my fork*, specifically.