### PR TITLE
Modularise CI workflow and validate outputs for binary size checks.

### DIFF
--- a/.github/actions/build-with-patched-std/action.yml
+++ b/.github/actions/build-with-patched-std/action.yml
@@ -1,0 +1,48 @@
+# Github composite action to build a single-source-file test binary with an
+# already-checked-out version of Rust's stdlib, that will be patched with a
+# given revision of the backtrace crate.
+
+name: Build with patched std
+description: >
+  Build a binary with a version of std that's had a specific revision of
+  backtrace patched in.
+inputs:
+  backtrace-commit:
+    description: The git commit of backtrace to patch in to std
+    required: true
+  main-rs:
+    description: The (single) source code file to compile
+    required: true
+  rustc-dir:
+    description: The root directory of the rustc repo
+    required: true
+outputs:
+  test-binary-size:
+    description: The size in bytes of the built test binary
+    value: ${{ steps.measure.outputs.test-binary-size }}
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      id: measure
+      env:
+        RUSTC_FLAGS: -Copt-level=3 -Cstrip=symbols
+        # This symlink is made by Build::new() in the bootstrap crate, using a
+        # symlink on Linux and a junction on Windows, so it will exist on both
+        # platforms.
+        RUSTC_BUILD_DIR: build/host
+      working-directory: ${{ inputs.rustc-dir }}
+      run: |
+        rm -rf "$RUSTC_BUILD_DIR/stage0-std"
+
+        (cd library/backtrace && git checkout ${{ inputs.backtrace-commit }})
+        git add library/backtrace
+
+        python3 x.py build library --stage 0
+
+        TEMP_BUILD_OUTPUT=$(mktemp test-binary-XXXXXXXX)
+        "$RUSTC_BUILD_DIR/stage0-sysroot/bin/rustc" $RUSTC_FLAGS "${{ inputs.main-rs }}" -o "$TEMP_BUILD_OUTPUT"
+        BINARY_SIZE=$(stat -c '%s' "$TEMP_BUILD_OUTPUT")
+        rm "$TEMP_BUILD_OUTPUT"
+
+        echo "test-binary-size=$BINARY_SIZE" >> "$GITHUB_OUTPUT"

--- a/.github/actions/report-code-size-changes/action.yml
+++ b/.github/actions/report-code-size-changes/action.yml
@@ -1,14 +1,21 @@
-# Github composite action to report on code size changes
+# Github composite action to report on code size changes across different
+# platforms.
+
 name: Report binary size changes on PR
 description: |
-  Report on code size changes resulting from a PR as a comment on the PR
-  (accessed via context).
+  Report on code size changes across different platforms resulting from a PR.
+  The only input argument is the path to a directory containing a set of
+  "*.json" files (extension required), each file containing the keys:
+
+   - platform: the platform that the code size change was measured on
+   - reference: the size in bytes of the reference binary (base of PR)
+   - updated: the size in bytes of the updated binary (head of PR)
+
+  The size is reported as a comment on the PR (accessed via context).
 inputs:
-   reference:
-    description: The size in bytes of the reference binary (base of PR).
-    required: true
-   updated:
-    description: The size in bytes of the updated binary (head of PR).
+  data-directory:
+    description: >
+      Path to directory containing size data as a set of "*.json" files.
     required: true
 runs:
   using: composite
@@ -16,56 +23,89 @@ runs:
     - name: Post a PR comment if the size has changed
       uses: actions/github-script@v6
       env:
-        SIZE_REFERENCE: ${{ inputs.reference }}
-        SIZE_UPDATED: ${{ inputs.updated }}
+        DATA_DIRECTORY: ${{ inputs.data-directory }}
       with:
         script: |
-          const reference = process.env.SIZE_REFERENCE;
-          const updated = process.env.SIZE_UPDATED;
+          const fs = require("fs");
 
-          if (!(reference > 0)) {
-            core.setFailed(`Reference size invalid: ${reference}`);
-            return;
-          }
+          const size_dir = process.env.DATA_DIRECTORY;
 
-          if (!(updated > 0)) {
-            core.setFailed(`Updated size invalid: ${updated}`);
-            return;
-          }
+          // Map the set of all the *.json files into an array of objects.
+          const globber = await glob.create(`${size_dir}/*.json`);
+          const files = await globber.glob();
+          const sizes = files.map(path => {
+            const contents = fs.readFileSync(path);
+            return JSON.parse(contents);
+          });
 
-          const formatter = Intl.NumberFormat("en", {useGrouping: "always"});
+          // Map each object into some text, but only if it shows any difference
+          // to report.
+          const size_reports = sizes.flatMap(size_data => {
+            const platform = size_data["platform"];
+            const reference = size_data["reference"];
+            const updated = size_data["updated"];
 
-          const updated_str = formatter.format(updated);
-          const reference_str = formatter.format(reference);
+            if (!(reference > 0)) {
+              core.setFailed(`Reference size invalid: ${reference}`);
+              return;
+            }
 
-          const diff = updated - reference;
-          const diff_pct = (updated / reference) - 1;
+            if (!(updated > 0)) {
+              core.setFailed(`Updated size invalid: ${updated}`);
+              return;
+            }
 
-          const diff_str = Intl.NumberFormat("en", {
-            useGrouping: "always",
-            sign: "exceptZero"
-          }).format(diff);
+            const formatter = Intl.NumberFormat("en", {
+              useGrouping: "always"
+            });
 
-          const diff_pct_str = Intl.NumberFormat("en", {
-            style: "percent",
-            useGrouping: "always",
-            sign: "exceptZero",
-            maximumFractionDigits: 2
-          }).format(diff_pct);
+            const updated_str = formatter.format(updated);
+            const reference_str = formatter.format(reference);
 
-          if (diff !== 0) {
-            // The body is created here and wrapped so "weirdly" to avoid whitespace at the start of the lines,
-            // which is interpreted as a code block by Markdown.
-            const body = `Below is the size of a hello-world Rust program linked with libstd with backtrace.
+            const diff = updated - reference;
+            const diff_pct = (updated / reference) - 1;
 
-          Original binary size: **${reference_str} B**
-          Updated binary size: **${updated_str} B**
-          Difference: **${diff_str} B** (${diff_pct_str})`;
+            const diff_str = Intl.NumberFormat("en", {
+              useGrouping: "always",
+              sign: "exceptZero"
+            }).format(diff);
+
+            const diff_pct_str = Intl.NumberFormat("en", {
+              style: "percent",
+              useGrouping: "always",
+              sign: "exceptZero",
+              maximumFractionDigits: 2
+            }).format(diff_pct);
+
+            if (diff !== 0) {
+              // The body is created here and wrapped so "weirdly" to avoid whitespace at the start of the lines,
+              // which is interpreted as a code block by Markdown.
+              const report = `On platform \`${platform}\`:
+
+          - Original binary size: **${reference_str} B**
+          - Updated binary size: **${updated_str} B**
+          - Difference: **${diff_str} B** (${diff_pct_str})
+
+          `;
+
+              return [report];
+            } else {
+              return [];
+            }
+          });
+
+          // If there are any size changes to report, format a comment and post
+          // it.
+          if (size_reports.length > 0) {
+            const comment_sizes = size_reports.join("");
+            const body = `Code size changes for a hello-world Rust program linked with libstd with backtrace:
+
+          ${comment_sizes}`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body
-            })
+            });
           }

--- a/.github/actions/report-code-size-changes/action.yml
+++ b/.github/actions/report-code-size-changes/action.yml
@@ -33,19 +33,34 @@ runs:
             return;
           }
 
+          const formatter = Intl.NumberFormat("en", {useGrouping: "always"});
+
+          const updated_str = formatter.format(updated);
+          const reference_str = formatter.format(reference);
+
           const diff = updated - reference;
-          const plus = diff > 0 ? "+" : "";
-          const diff_str = `${plus}${diff}B`;
+          const diff_pct = (updated / reference) - 1;
+
+          const diff_str = Intl.NumberFormat("en", {
+            useGrouping: "always",
+            sign: "exceptZero"
+          }).format(diff);
+
+          const diff_pct_str = Intl.NumberFormat("en", {
+            style: "percent",
+            useGrouping: "always",
+            sign: "exceptZero",
+            maximumFractionDigits: 2
+          }).format(diff_pct);
 
           if (diff !== 0) {
-            const percent = (((updated / reference) - 1) * 100).toFixed(2);
             // The body is created here and wrapped so "weirdly" to avoid whitespace at the start of the lines,
             // which is interpreted as a code block by Markdown.
             const body = `Below is the size of a hello-world Rust program linked with libstd with backtrace.
 
-          Original binary size: **${reference}B**
-          Updated binary size: **${updated}B**
-          Difference: **${diff_str}** (${percent}%)`;
+          Original binary size: **${reference_str} B**
+          Updated binary size: **${updated_str} B**
+          Difference: **${diff_str} B** (${diff_pct_str})`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/actions/report-code-size-changes/action.yml
+++ b/.github/actions/report-code-size-changes/action.yml
@@ -1,0 +1,56 @@
+# Github composite action to report on code size changes
+name: Report binary size changes on PR
+description: |
+  Report on code size changes resulting from a PR as a comment on the PR
+  (accessed via context).
+inputs:
+   reference:
+    description: The size in bytes of the reference binary (base of PR).
+    required: true
+   updated:
+    description: The size in bytes of the updated binary (head of PR).
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Post a PR comment if the size has changed
+      uses: actions/github-script@v6
+      env:
+        SIZE_REFERENCE: ${{ inputs.reference }}
+        SIZE_UPDATED: ${{ inputs.updated }}
+      with:
+        script: |
+          const reference = process.env.SIZE_REFERENCE;
+          const updated = process.env.SIZE_UPDATED;
+
+          if (!(reference > 0)) {
+            core.setFailed(`Reference size invalid: ${reference}`);
+            return;
+          }
+
+          if (!(updated > 0)) {
+            core.setFailed(`Updated size invalid: ${updated}`);
+            return;
+          }
+
+          const diff = updated - reference;
+          const plus = diff > 0 ? "+" : "";
+          const diff_str = `${plus}${diff}B`;
+
+          if (diff !== 0) {
+            const percent = (((updated / reference) - 1) * 100).toFixed(2);
+            // The body is created here and wrapped so "weirdly" to avoid whitespace at the start of the lines,
+            // which is interpreted as a code block by Markdown.
+            const body = `Below is the size of a hello-world Rust program linked with libstd with backtrace.
+
+          Original binary size: **${reference}B**
+          Updated binary size: **${updated}B**
+          Difference: **${diff_str}** (${percent}%)`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            })
+          }

--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -94,44 +94,10 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Post a PR comment if the size has changed
-        uses: actions/github-script@v6
-        env:
-          SIZE_REFERENCE: ${{ needs.measure.outputs.binary-size-reference }}
-          SIZE_UPDATED: ${{ needs.measure.outputs.binary-size-updated }}
+      # Clone backtrace to access Github composite actions to report size.
+      - uses: actions/checkout@v3
+      # Run the size reporting action.
+      - uses: ./.github/actions/report-code-size-changes
         with:
-          script: |
-            const reference = process.env.SIZE_REFERENCE;
-            const updated = process.env.SIZE_UPDATED;
-
-            if (!(reference > 0)) {
-              core.setFailed(`Reference size invalid: ${reference}`);
-              return;
-            }
-
-            if (!(updated > 0)) {
-              core.setFailed(`Updated size invalid: ${updated}`);
-              return;
-            }
-
-            const diff = updated - reference;
-            const plus = diff > 0 ? "+" : "";
-            const diff_str = `${plus}${diff}B`;
-
-            if (diff !== 0) {
-              const percent = (((updated / reference) - 1) * 100).toFixed(2);
-              // The body is created here and wrapped so "weirdly" to avoid whitespace at the start of the lines,
-              // which is interpreted as a code block by Markdown.
-              const body = `Below is the size of a hello-world Rust program linked with libstd with backtrace.
-
-            Original binary size: **${reference}B**
-            Updated binary size: **${updated}B**
-            Difference: **${diff_str}** (${percent}%)`;
-
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body
-              })
-            }
+          reference: ${{ needs.measure.outputs.binary-size-reference }}
+          updated: ${{ needs.measure.outputs.binary-size-updated }}

--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -9,13 +9,20 @@ on:
     branches:
       - master
 
+# Both the "measure" and "report" jobs need to know this.
+env:
+  SIZE_DATA_DIR: sizes
+
 # Responsibility is divided between two jobs "measure" and "report", so that the
 # job that builds (and potentnially runs) untrusted code does not have PR write
 # permission, and vice-versa.
 jobs:
   measure:
     name: Check binary size
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
     permissions:
       contents: read
     env:
@@ -26,9 +33,7 @@ jobs:
       TEST_MAIN_RS: foo.rs
       BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
       HEAD_COMMIT: ${{ github.event.pull_request.head.sha }}
-    outputs:
-      binary-size-reference: ${{ steps.size-reference.outputs.test-binary-size }}
-      binary-size-updated: ${{ steps.size-updated.outputs.test-binary-size }}
+      SIZE_DATA_FILE: size-${{ strategy.job-index }}.json
     steps:
       - name: Print info
         shell: bash
@@ -37,7 +42,7 @@ jobs:
           echo "Base SHA: $BASE_COMMIT"
       # Note: the backtrace source that's cloned here is NOT the version to be
       # patched in to std. It's cloned here to access the Github action for
-      # building the test binary and measuring its size.
+      # building and measuring the test binary.
       - name: Clone backtrace to access Github action
         uses: actions/checkout@v3
         with:
@@ -87,6 +92,45 @@ jobs:
           main-rs: ${{ env.TEST_MAIN_RS }}
           rustc-dir: ${{ env.RUSTC_DIR }}
         id: size-updated
+      # There is no built-in way to "collect" all the outputs of a set of jobs
+      # run with a matrix strategy. Subsequent jobs that have a "needs"
+      # dependency on this one will be run once, when the last matrix job is
+      # run. Appending data to a single file within a matrix is subject to race
+      # conditions. So we write the size data to files with distinct names
+      # generated from the job index.
+      - name: Write sizes to file
+        uses: actions/github-script@v6
+        env:
+          SIZE_REFERENCE: ${{ steps.size-reference.outputs.test-binary-size }}
+          SIZE_UPDATED: ${{ steps.size-updated.outputs.test-binary-size }}
+          PLATFORM: ${{ matrix.platform }}
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+
+            fs.mkdirSync(process.env.SIZE_DATA_DIR, {recursive: true});
+
+            const output_data = JSON.stringify({
+              platform: process.env.PLATFORM,
+              reference: process.env.SIZE_REFERENCE,
+              updated: process.env.SIZE_UPDATED,
+            });
+
+            // The "wx" flag makes this fail if the file exists, which we want,
+            // because there should be no collisions.
+            fs.writeFileSync(
+              path.join(process.env.SIZE_DATA_DIR, process.env.SIZE_DATA_FILE),
+              output_data,
+              { flag: "wx" },
+            );
+      - name: Upload size data
+        uses: actions/upload-artifact@v3
+        with:
+          name: size-files
+          path: ${{ env.SIZE_DATA_DIR }}/${{ env.SIZE_DATA_FILE }}
+          retention-days: 1
+          if-no-files-found: error
   report:
     name: Report binary size changes
     runs-on: ubuntu-latest
@@ -96,8 +140,12 @@ jobs:
     steps:
       # Clone backtrace to access Github composite actions to report size.
       - uses: actions/checkout@v3
-      # Run the size reporting action.
-      - uses: ./.github/actions/report-code-size-changes
+      - name: Download size data
+        uses: actions/download-artifact@v3
         with:
-          reference: ${{ needs.measure.outputs.binary-size-reference }}
-          updated: ${{ needs.measure.outputs.binary-size-updated }}
+          name: size-files
+          path: ${{ env.SIZE_DATA_DIR }}
+      - name: Analyze and report size changes
+        uses: ./.github/actions/report-code-size-changes
+        with:
+          data-directory: ${{ env.SIZE_DATA_DIR }}

--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -9,12 +9,15 @@ on:
     branches:
       - master
 
+# Responsibility is divided between two jobs "measure" and "report", so that the
+# job that builds (and potentnially runs) untrusted code does not have PR write
+# permission, and vice-versa.
 jobs:
-  test:
+  measure:
     name: Check binary size
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      contents: read
     env:
       # This cannot be used as a context variable in the 'uses' key later. If it
       # changes, update those steps too.
@@ -23,6 +26,9 @@ jobs:
       TEST_MAIN_RS: foo.rs
       BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
       HEAD_COMMIT: ${{ github.event.pull_request.head.sha }}
+    outputs:
+      binary-size-reference: ${{ steps.size-reference.outputs.test-binary-size }}
+      binary-size-updated: ${{ steps.size-updated.outputs.test-binary-size }}
     steps:
       - name: Print info
         shell: bash
@@ -81,11 +87,18 @@ jobs:
           main-rs: ${{ env.TEST_MAIN_RS }}
           rustc-dir: ${{ env.RUSTC_DIR }}
         id: size-updated
+  report:
+    name: Report binary size changes
+    runs-on: ubuntu-latest
+    needs: measure
+    permissions:
+      pull-requests: write
+    steps:
       - name: Post a PR comment if the size has changed
         uses: actions/github-script@v6
         env:
-          SIZE_REFERENCE: ${{ steps.size-reference.outputs.test-binary-size }}
-          SIZE_UPDATED: ${{ steps.size-updated.outputs.test-binary-size }}
+          SIZE_REFERENCE: ${{ needs.measure.outputs.binary-size-reference }}
+          SIZE_UPDATED: ${{ needs.measure.outputs.binary-size-updated }}
         with:
           script: |
             const reference = process.env.SIZE_REFERENCE;

--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -15,51 +15,92 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    env:
+      # This cannot be used as a context variable in the 'uses' key later. If it
+      # changes, update those steps too.
+      BACKTRACE_DIR: backtrace
+      RUSTC_DIR: rustc
+      TEST_MAIN_RS: foo.rs
+      BASE_COMMIT: ${{ github.event.pull_request.base.sha }}
+      HEAD_COMMIT: ${{ github.event.pull_request.head.sha }}
     steps:
       - name: Print info
+        shell: bash
         run: |
-          echo "Current SHA: ${{ github.event.pull_request.head.sha }}"
-          echo "Base SHA: ${{ github.event.pull_request.base.sha }}"
+          echo "Current SHA: $HEAD_COMMIT"
+          echo "Base SHA: $BASE_COMMIT"
+      # Note: the backtrace source that's cloned here is NOT the version to be
+      # patched in to std. It's cloned here to access the Github action for
+      # building the test binary and measuring its size.
+      - name: Clone backtrace to access Github action
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.BACKTRACE_DIR }}
       - name: Clone Rustc
         uses: actions/checkout@v3
         with:
           repository: rust-lang/rust
-          fetch-depth: 1
-      - name: Fetch backtrace
-        run: git submodule update --init library/backtrace
-      - name: Create hello world program that uses backtrace
-        run: printf "fn main() { panic!(); }" > foo.rs
-      - name: Build binary with base version of backtrace
+          path: ${{ env.RUSTC_DIR }}
+      - name: Set up std repository and backtrace submodule for size test
+        shell: bash
+        working-directory: ${{ env.RUSTC_DIR }}
+        env:
+          PR_SOURCE_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
-          printf "[llvm]\ndownload-ci-llvm = true\n\n[rust]\nincremental = false\n" > config.toml
+          # Bootstrap config
+          cat <<EOF > config.toml
+          [llvm]
+          download-ci-llvm = true
+          [rust]
+          incremental = false
+          EOF
+
+          # Test program source
+          cat <<EOF > $TEST_MAIN_RS
+          fn main() {
+            panic!();
+          }
+          EOF
+
+          git submodule update --init library/backtrace
+
           cd library/backtrace
-          git remote add head-pr https://github.com/${{ github.event.pull_request.head.repo.full_name }}
+          git remote add head-pr "https://github.com/$PR_SOURCE_REPO"
           git fetch --all
-          git checkout ${{ github.event.pull_request.base.sha }}
-          cd ../..
-          git add library/backtrace
-          python3 x.py build library --stage 0
-          ./build/x86_64-unknown-linux-gnu/stage0-sysroot/bin/rustc -O foo.rs -o binary-reference
+      - name: Build binary with base version of backtrace
+        uses: ./backtrace/.github/actions/build-with-patched-std
+        with:
+          backtrace-commit: ${{ env.BASE_COMMIT }}
+          main-rs: ${{ env.TEST_MAIN_RS }}
+          rustc-dir: ${{ env.RUSTC_DIR }}
+        id: size-reference
       - name: Build binary with PR version of backtrace
-        run: |
-          cd library/backtrace
-          git checkout ${{ github.event.pull_request.head.sha }}
-          cd ../..
-          git add library/backtrace
-          rm -rf build/x86_64-unknown-linux-gnu/stage0-std
-          python3 x.py build library --stage 0
-          ./build/x86_64-unknown-linux-gnu/stage0-sysroot/bin/rustc -O foo.rs -o binary-updated
-      - name: Display binary size
-        run: |
-          ls -la binary-*
-          echo "SIZE_REFERENCE=$(stat -c '%s' binary-reference)" >> "$GITHUB_ENV"
-          echo "SIZE_UPDATED=$(stat -c '%s' binary-updated)" >> "$GITHUB_ENV"
+        uses: ./backtrace/.github/actions/build-with-patched-std
+        with:
+          backtrace-commit: ${{ env.HEAD_COMMIT }}
+          main-rs: ${{ env.TEST_MAIN_RS }}
+          rustc-dir: ${{ env.RUSTC_DIR }}
+        id: size-updated
       - name: Post a PR comment if the size has changed
         uses: actions/github-script@v6
+        env:
+          SIZE_REFERENCE: ${{ steps.size-reference.outputs.test-binary-size }}
+          SIZE_UPDATED: ${{ steps.size-updated.outputs.test-binary-size }}
         with:
           script: |
             const reference = process.env.SIZE_REFERENCE;
             const updated = process.env.SIZE_UPDATED;
+
+            if (!(reference > 0)) {
+              core.setFailed(`Reference size invalid: ${reference}`);
+              return;
+            }
+
+            if (!(updated > 0)) {
+              core.setFailed(`Updated size invalid: ${updated}`);
+              return;
+            }
+
             const diff = updated - reference;
             const plus = diff > 0 ? "+" : "";
             const diff_str = `${plus}${diff}B`;


### PR DESCRIPTION
I was amazed at how quickly you spun up your code size check CI workflow. It prompted me to take that approach and play around with it in a private repo to dig into it more, which resulted in these changes and notes you might be interested in.

Notes:

## Modularisation

Most of the workflow structure changes were just to help me understand the process. I found it useful to separate the step that does the code size check itself from all the prep work. This same separation lent itself well to eg. converting the workflow into a Docker multi-stage image so I could automate running the measurement over a lot of commits in the history.

Modularising CI workflow this way is kind of a style preference though, so feel free to decline/bikeshed that aspect of it.

## Compiler flags

I changed the flags to optimise for size and strip all symbols, because that is generally the lowest hanging fruit for anyone concerned about binary size and might reflect the more "realistic" impact on such a project. OTOH, I don't think the difference in flags would actually turn a change in size into a non-change, so you might consider it spurious.

## Transitive dependency breaks

One large-ish problem I found with _historical_ analysis was that, specifically, I wanted to understand the jump in size between `nightly-2023-07-01` and `nightly-2023-07-03`. This was a change in backtrace:

- from 0.3.67 / `8ad84ca5ad88ade697637387e7cb4d7c3cf4bde8`
- to 0.3.68 / `e1c49fbd6124a1b626cdf19871aff68c362bdf07`

The problem is, running the "build with patched std" procedure on the old commit resulted in errors:

<details>
<summary>
(Expand for the full output.)

```none
error[E0308]: mismatched types
   --> library/std/src/../../backtrace/src/symbolize/gimli.rs:377:24
    |
377 |                 if let Ok(mut frames) = object_cx.dwarf.find_frames(object_addr) {
    |                        ^^^^^^^^^^^^^^   ---------------------------------------- this expression has type `LookupResult<impl LookupContinuation<Output = core::result::Result<FrameIter<'_, EndianSlice<'_, addr2line::gimli::LittleEndian>>, addr2line::gimli::Error>, Buf = EndianSlice<'_, addr2line::gimli::LittleEndian>>>`
    |                        |
    |                        expected `LookupResult<impl LookupContinuation<Output = ..., Buf = ...>>`, found `Result<_, _>`
    |
   ::: /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/addr2line-0.20.0/src/lib.rs:450:23
    |
450 | ...lt<impl LookupContinuation<Output = Result<FrameIter<'_, R>, Error>, Buf = R>>
    |       -------------------------------------------------------------------------- the expected opaque type
    |
    = note: expected enum `LookupResult<impl LookupContinuation<Output = ..., Buf = ...>>`
            the full type name has been written to '/rust/build/x86_64-unknown-linux-gnu/stage0-std/x86_64-unknown-linux-gnu/release/deps/std-561bd21e49def8cf.long-type-9162012492364665641.txt'
               found enum `core::result::Result<_, _>`
```
</summary>

```none
root@3770f30d41d9:/rust# python3 x.py build library --stage 0
Building bootstrap
    Finished dev [unoptimized] target(s) in 0.04s
warning: x.py has made several changes recently you may want to look at
help: consider looking at the changes in `src/bootstrap/CHANGELOG.md`
note: to silence this warning, add `changelog-seen = 2` at the top of `config.toml`
Updating submodule src/tools/cargo
Submodule 'src/tools/cargo' (https://github.com/rust-lang/cargo.git) registered for path 'src/tools/cargo'
Cloning into '/rust/src/tools/cargo'...
remote: Enumerating objects: 1896, done.        
remote: Counting objects: 100% (1896/1896), done.        
remote: Compressing objects: 100% (1358/1358), done.        
remote: Total 1896 (delta 468), reused 1094 (delta 343), pack-reused 0        
Receiving objects: 100% (1896/1896), 2.73 MiB | 1.73 MiB/s, done.
Resolving deltas: 100% (468/468), done.
remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
remote: Enumerating objects: 32, done.
remote: Counting objects: 100% (32/32), done.
remote: Compressing objects: 100% (14/14), done.
remote: Total 17 (delta 15), reused 5 (delta 3), pack-reused 0
Unpacking objects: 100% (17/17), 6.95 KiB | 790.00 KiB/s, done.
From https://github.com/rust-lang/cargo
 * branch            5b377cece0e0dd0af686cf53ce4637d5d85c2a10 -> FETCH_HEAD
Submodule path 'src/tools/cargo': checked out '5b377cece0e0dd0af686cf53ce4637d5d85c2a10'
Updating submodule library/backtrace
Updating submodule library/stdarch
Submodule 'library/stdarch' (https://github.com/rust-lang/stdarch.git) registered for path 'library/stdarch'
Cloning into '/rust/library/stdarch'...
remote: Enumerating objects: 302, done.        
remote: Counting objects: 100% (302/302), done.        
remote: Compressing objects: 100% (247/247), done.        
remote: Total 302 (delta 45), reused 155 (delta 22), pack-reused 0        
Receiving objects: 100% (302/302), 1.16 MiB | 2.60 MiB/s, done.
Resolving deltas: 100% (45/45), done.
remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
remote: Enumerating objects: 87, done.
remote: Counting objects: 100% (87/87), done.
remote: Compressing objects: 100% (46/46), done.
remote: Total 50 (delta 33), reused 13 (delta 3), pack-reused 0
Unpacking objects: 100% (50/50), 104.11 KiB | 1.12 MiB/s, done.
From https://github.com/rust-lang/stdarch
 * branch            d77878b7299dd7e286799a6e8447048b65d2a861 -> FETCH_HEAD
Submodule path 'library/stdarch': checked out 'd77878b7299dd7e286799a6e8447048b65d2a861'
Updating submodule library/backtrace
downloading https://static.rust-lang.org/dist/2023-05-30/rustfmt-nightly-x86_64-unknown-linux-gnu.tar.xz
######################################################################################### 100.0%
extracting /rust/build/cache/2023-05-30/rustfmt-nightly-x86_64-unknown-linux-gnu.tar.xz to /rust/build/x86_64-unknown-linux-gnu/rustfmt
downloading https://static.rust-lang.org/dist/2023-05-30/rustc-nightly-x86_64-unknown-linux-gnu.tar.xz
######################################################################################### 100.0%
extracting /rust/build/cache/2023-05-30/rustc-nightly-x86_64-unknown-linux-gnu.tar.xz to /rust/build/x86_64-unknown-linux-gnu/rustfmt
downloading https://ci-artifacts.rust-lang.org/rustc-builds/4b6749b21e680a6280cf05ace533ae20c93d9bff/rust-dev-nightly-x86_64-unknown-linux-gnu.tar.xz
######################################################################################### 100.0%
extracting /rust/build/cache/llvm-4b6749b21e680a6280cf05ace533ae20c93d9bff-false/rust-dev-nightly-x86_64-unknown-linux-gnu.tar.xz to /rust/build/x86_64-unknown-linux-gnu/ci-llvm
Building stage0 library artifacts (x86_64-unknown-linux-gnu)
    Updating crates.io index
  Downloaded addr2line v0.20.0
  Downloaded miniz_oxide v0.7.1
  Downloaded unicode-width v0.1.10
  Downloaded adler v1.0.2
  Downloaded getopts v0.2.21
  Downloaded rustc-demangle v0.1.23
  Downloaded allocator-api2 v0.2.15
  Downloaded cc v1.0.79
  Downloaded hashbrown v0.14.0
  Downloaded compiler_builtins v0.1.93
  Downloaded libc v0.2.147
  Downloaded gimli v0.27.3
  Downloaded 12 crates (1.6 MB) in 1.34s
   Compiling compiler_builtins v0.1.93
   Compiling core v0.0.0 (/rust/library/core)
   Compiling libc v0.2.147
   Compiling cc v1.0.79
   Compiling memchr v2.5.0
   Compiling std v0.0.0 (/rust/library/std)
   Compiling unwind v0.0.0 (/rust/library/unwind)
   Compiling rustc-std-workspace-core v1.99.0 (/rust/library/rustc-std-workspace-core)
   Compiling alloc v0.0.0 (/rust/library/alloc)
   Compiling cfg-if v1.0.0
   Compiling adler v1.0.2
   Compiling rustc-demangle v0.1.23
   Compiling rustc-std-workspace-alloc v1.99.0 (/rust/library/rustc-std-workspace-alloc)
   Compiling panic_abort v0.0.0 (/rust/library/panic_abort)
   Compiling panic_unwind v0.0.0 (/rust/library/panic_unwind)
   Compiling gimli v0.27.3
   Compiling hashbrown v0.14.0
   Compiling miniz_oxide v0.7.1
   Compiling object v0.31.1
   Compiling std_detect v0.1.5 (/rust/library/stdarch/crates/std_detect)
   Compiling addr2line v0.20.0
error[E0308]: mismatched types
   --> library/std/src/../../backtrace/src/symbolize/gimli.rs:361:16
    |
361 |         if let Ok(mut frames) = cx.dwarf.find_frames(addr as u64) {
    |                ^^^^^^^^^^^^^^   --------------------------------- this expression has type `LookupResult<impl LookupContinuation<Output = core::result::Result<FrameIter<'_, EndianSlice<'_, addr2line::gimli::LittleEndian>>, addr2line::gimli::Error>, Buf = EndianSlice<'_, addr2line::gimli::LittleEndian>>>`
    |                |
    |                expected `LookupResult<impl LookupContinuation<Output = ..., Buf = ...>>`, found `Result<_, _>`
    |
   ::: /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/addr2line-0.20.0/src/lib.rs:450:23
    |
450 | ...lt<impl LookupContinuation<Output = Result<FrameIter<'_, R>, Error>, Buf = R>>
    |       -------------------------------------------------------------------------- the expected opaque type
    |
    = note: expected enum `LookupResult<impl LookupContinuation<Output = ..., Buf = ...>>`
            the full type name has been written to '/rust/build/x86_64-unknown-linux-gnu/stage0-std/x86_64-unknown-linux-gnu/release/deps/std-561bd21e49def8cf.long-type-12642544034931188750.txt'
               found enum `core::result::Result<_, _>`

error[E0308]: mismatched types
   --> library/std/src/../../backtrace/src/symbolize/gimli.rs:377:24
    |
377 |                 if let Ok(mut frames) = object_cx.dwarf.find_frames(object_addr) {
    |                        ^^^^^^^^^^^^^^   ---------------------------------------- this expression has type `LookupResult<impl LookupContinuation<Output = core::result::Result<FrameIter<'_, EndianSlice<'_, addr2line::gimli::LittleEndian>>, addr2line::gimli::Error>, Buf = EndianSlice<'_, addr2line::gimli::LittleEndian>>>`
    |                        |
    |                        expected `LookupResult<impl LookupContinuation<Output = ..., Buf = ...>>`, found `Result<_, _>`
    |
   ::: /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/addr2line-0.20.0/src/lib.rs:450:23
    |
450 | ...lt<impl LookupContinuation<Output = Result<FrameIter<'_, R>, Error>, Buf = R>>
    |       -------------------------------------------------------------------------- the expected opaque type
    |
    = note: expected enum `LookupResult<impl LookupContinuation<Output = ..., Buf = ...>>`
            the full type name has been written to '/rust/build/x86_64-unknown-linux-gnu/stage0-std/x86_64-unknown-linux-gnu/release/deps/std-561bd21e49def8cf.long-type-9162012492364665641.txt'
               found enum `core::result::Result<_, _>`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `std` (lib) due to 2 previous errors
Build completed unsuccessfully in 0:03:03
```
</details>

I'm not familiar enough with backtrace and std to interpret this. If it's because there's a change in interface between the two versions of backtrace, leading to incompatibilities where you can't just splice the new or old version into the same version of std — I don't know of a way around it with this approach except to do it manually with known, specific versions of std.

OTOH, if it's because of some transitive dependencies that are now mismatched between those calculated in some lockfile and those resolved during this later step, that might be something that could be dealt with in this process.

The reason I mention it is that this class of code size increase (due to changes in dependencies or ones use of them) can be amongst the biggest and most well-hidden (IME, anyway, because of the "but I didn't change any code!" factor). And so it might be the most worthy of being caught by CI, but I can't quite tell (a) if this approach misses it and, if so, (b) how to change it so it doesn't miss it.

## Sudden failure of copying files

**Update:** fixed now.

I was going to point you to [an example PR](https://github.com/detly/backtrace-rs/pull/3) I had in my own fork so you could verify that this worked. BUT in, literally, the 20 minutes it took me to write this PR, the workflow broke. Including ones that worked an hour ago. The [failure is](https://github.com/detly/backtrace-rs/actions/runs/5502836396/jobs/10027446552?pr=3#step:6:1051):

```none
cp: 'build/x86_64-unknown-linux-gnu/stage0/lib/libLLVM-16-rust-1.71.0-beta.so' and 'build/x86_64-unknown-linux-gnu/stage0-sysroot/lib/libLLVM-16-rust-1.71.0-beta.so' are the same file
cp: 'build/x86_64-unknown-linux-gnu/stage0/lib/librustc_driver-e73eb5c47f849c7b.so' and 'build/x86_64-unknown-linux-gnu/stage0-sysroot/lib/librustc_driver-e73eb5c47f849c7b.so' are the same file
cp: 'build/x86_64-unknown-linux-gnu/stage0/lib/libstd-9ef2a438251e3a63.so' and 'build/x86_64-unknown-linux-gnu/stage0-sysroot/lib/libstd-9ef2a438251e3a63.so' are the same file
cp: 'build/x86_64-unknown-linux-gnu/stage0/lib/libtest-c03aaf58feba71c6.so' and 'build/x86_64-unknown-linux-gnu/stage0-sysroot/lib/libtest-c03aaf58feba71c6.so' are the same file
```

I haven't debugged this yet, but it might be that something in the bootstrap process is (now) hardlinking outputs, and `cp` doesn't like that.