### PR TITLE
Omit copying patched std build output for checking binary size in CI

### DIFF
--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -39,8 +39,6 @@ jobs:
           cd ../..
           git add library/backtrace
           python3 x.py build library --stage 0
-          cp -r ./build/x86_64-unknown-linux-gnu/stage0/bin ./build/x86_64-unknown-linux-gnu/stage0-sysroot/bin
-          cp -r ./build/x86_64-unknown-linux-gnu/stage0/lib/*.so ./build/x86_64-unknown-linux-gnu/stage0-sysroot/lib
           ./build/x86_64-unknown-linux-gnu/stage0-sysroot/bin/rustc -O foo.rs -o binary-reference
       - name: Build binary with PR version of backtrace
         run: |
@@ -50,8 +48,6 @@ jobs:
           git add library/backtrace
           rm -rf build/x86_64-unknown-linux-gnu/stage0-std
           python3 x.py build library --stage 0
-          cp -r ./build/x86_64-unknown-linux-gnu/stage0/bin ./build/x86_64-unknown-linux-gnu/stage0-sysroot/bin
-          cp -r ./build/x86_64-unknown-linux-gnu/stage0/lib/*.so ./build/x86_64-unknown-linux-gnu/stage0-sysroot/lib
           ./build/x86_64-unknown-linux-gnu/stage0-sysroot/bin/rustc -O foo.rs -o binary-updated
       - name: Display binary size
         run: |


### PR DESCRIPTION
The CI workflow to check binary size started failing for me a few hours ago, and in [this repo too](https://github.com/rust-lang/backtrace-rs/actions/runs/5502862836/jobs/10027500598?pr=549) now. The error happens when the bootstrapped files are copied over to be used for building a test binary; `cp` says:

```none
cp: './build/x86_64-unknown-linux-gnu/stage0/lib/libLLVM-16-rust-1.71.0-beta.so' and './build/x86_64-unknown-linux-gnu/stage0-sysroot/lib/libLLVM-16-rust-1.71.0-beta.so' are the same file
```

I have confirmed manually (in a Docker container) that this is because the files have the same inode ie. they are hardlinks. Using the `--remove-destination` flag allows the copy to proceed. Neither the `-f` (force) nor `-u` (update) flags will.

(I was not able to figure out _why_ they are suddenly hardlinks today, but I thought I'd share the change in case it saved some time.)