### PR TITLE
[DO NOT MERGE] Experiment with `RtlCaptureStackBackTrace`

### DIFF
--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -153,8 +153,6 @@ cfg_if::cfg_if! {
         mod dbghelp;
         use self::dbghelp::trace as trace_imp;
         pub(crate) use self::dbghelp::Frame as FrameImp;
-        #[cfg(target_env = "msvc")] // only used in dbghelp symbolize
-        pub(crate) use self::dbghelp::StackFrame;
     } else {
         mod noop;
         use self::noop::trace as trace_imp;

--- a/src/dbghelp.rs
+++ b/src/dbghelp.rs
@@ -34,8 +34,8 @@ use core::ptr;
 mod dbghelp {
     use crate::windows::*;
     pub use winapi::um::dbghelp::{
-        StackWalk64, StackWalkEx, SymCleanup, SymFromAddrW, SymFunctionTableAccess64,
-        SymGetLineFromAddrW64, SymGetModuleBase64, SymGetOptions, SymInitializeW, SymSetOptions,
+        SymCleanup, SymFromAddrW, SymFunctionTableAccess64, SymGetLineFromAddrW64,
+        SymGetModuleBase64, SymGetOptions, SymInitializeW, SymSetOptions,
     };
 
     extern "system" {
@@ -165,17 +165,6 @@ dbghelp! {
             invade: BOOL
         ) -> BOOL;
         fn SymCleanup(handle: HANDLE) -> BOOL;
-        fn StackWalk64(
-            MachineType: DWORD,
-            hProcess: HANDLE,
-            hThread: HANDLE,
-            StackFrame: LPSTACKFRAME64,
-            ContextRecord: PVOID,
-            ReadMemoryRoutine: PREAD_PROCESS_MEMORY_ROUTINE64,
-            FunctionTableAccessRoutine: PFUNCTION_TABLE_ACCESS_ROUTINE64,
-            GetModuleBaseRoutine: PGET_MODULE_BASE_ROUTINE64,
-            TranslateAddress: PTRANSLATE_ADDRESS_ROUTINE64
-        ) -> BOOL;
         fn SymFunctionTableAccess64(
             hProcess: HANDLE,
             AddrBase: DWORD64
@@ -195,18 +184,6 @@ dbghelp! {
             dwAddr: DWORD64,
             pdwDisplacement: PDWORD,
             Line: PIMAGEHLP_LINEW64
-        ) -> BOOL;
-        fn StackWalkEx(
-            MachineType: DWORD,
-            hProcess: HANDLE,
-            hThread: HANDLE,
-            StackFrame: LPSTACKFRAME_EX,
-            ContextRecord: PVOID,
-            ReadMemoryRoutine: PREAD_PROCESS_MEMORY_ROUTINE64,
-            FunctionTableAccessRoutine: PFUNCTION_TABLE_ACCESS_ROUTINE64,
-            GetModuleBaseRoutine: PGET_MODULE_BASE_ROUTINE64,
-            TranslateAddress: PTRANSLATE_ADDRESS_ROUTINE64,
-            Flags: DWORD
         ) -> BOOL;
         fn SymFromInlineContextW(
             hProcess: HANDLE,


### PR DESCRIPTION
Experiment with `RtlCaptureStackBackTrace` as per #535. This is not intended to be merged. I'm leaving this here temporarily in case anyone wants to use it to experiment further.

The great thing about `RtlCaptureStackBackTrace` is that it doesn't require symbol loading and simply works across architectures without much fuss. This decouples symbol loading from tracing and allows a more lightweight way of storing backtrace information if you don't mind looking up the symbols later. The big downside is that it only gets the `ip`. Also I'm seeing off-by-one line numbers in `tests\accuracy`. Probably because of the more limited info.

`RtlVirtualUnwind` has the same advantages as `RtlCaptureStackBackTrace` and also provide all the information you need (symbols aside). However, it is much more involved and it isn't supported by x86. Still, it might be a better direction to go in.