### PR TITLE
Enable calling build.rs directly from std/build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,10 @@
 extern crate cc;
 
 use std::env;
+use std::path::Path;
 
-fn main() {
+// Must be public so the build script of `std` can call it.
+pub fn main() {
     match env::var("CARGO_CFG_TARGET_OS").unwrap_or_default().as_str() {
         "android" => build_android(),
         _ => {}
@@ -10,7 +12,13 @@ fn main() {
 }
 
 fn build_android() {
-    let expansion = match cc::Build::new().file("src/android-api.c").try_expand() {
+    // Resolve `src/android-api.c` relative to this file.
+    // Required to support calling this from the `std` build script.
+    let android_api_c = Path::new(file!())
+        .parent()
+        .unwrap()
+        .join("src/android-api.c");
+    let expansion = match cc::Build::new().file(android_api_c).try_expand() {
         Ok(result) => result,
         Err(e) => {
             println!("failed to run C compiler: {}", e);

--- a/crates/as-if-std/Cargo.toml
+++ b/crates/as-if-std/Cargo.toml
@@ -24,6 +24,10 @@ default-features = false
 optional = true
 features = ['read_core', 'elf', 'macho', 'pe', 'unaligned', 'archive']
 
+[build-dependencies]
+# Dependency of the `backtrace` crate
+cc = "1.0.67"
+
 [features]
 default = ['backtrace']
 backtrace = ['addr2line', 'object']

--- a/crates/as-if-std/build.rs
+++ b/crates/as-if-std/build.rs
@@ -1,3 +1,11 @@
+// backtrace-rs requires a feature check on Android targets, so
+// we need to run its build.rs as well.
+#[allow(unused_extern_crates)]
+#[path = "../../build.rs"]
+mod backtrace_build_rs;
+
 fn main() {
     println!("cargo:rustc-cfg=backtrace_in_libstd");
+
+    backtrace_build_rs::main();
 }


### PR DESCRIPTION
This, I feel, is a slightly better way of achieving https://github.com/rust-lang/rust/pull/99883

Once this is merged, and backtrace is synced to rust-lang/rust, [this patch (based on that PR)](https://github.com/rust-lang/rust/compare/master...pitaj:rust:android-backtrace-build) can be applied to rust-lang/rust.