### PR TITLE
Use extended symbolization markup on Fuchsia

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -83,7 +83,8 @@ impl<'a, 'b> BacktraceFmt<'a, 'b> {
     /// This is currently a no-op but is added for future compatibility with
     /// backtrace formats.
     pub fn finish(&mut self) -> fmt::Result {
-        // Currently a no-op-- including this hook to allow for future additions.
+        #[cfg(target_os = "fuchsia")]
+        fuchsia::finish_context(self.fmt)?;
         Ok(())
     }
 

--- a/src/print/fuchsia.rs
+++ b/src/print/fuchsia.rs
@@ -425,7 +425,7 @@ impl DsoPrinter<'_, '_> {
 
 /// This function prints the Fuchsia symbolizer markup for all information contained in a DSO.
 pub fn print_dso_context(out: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    out.write_str("{{{reset}}}\n")?;
+    out.write_str("{{{reset:begin}}}\n")?;
     let mut visitor = DsoPrinter {
         writer: out,
         module_count: 0,
@@ -433,4 +433,9 @@ pub fn print_dso_context(out: &mut core::fmt::Formatter<'_>) -> core::fmt::Resul
     };
     for_each_dso(&mut visitor);
     visitor.error
+}
+
+/// This function prints the Fuchsia symbolizer markup to end the backtrace.
+pub fn finish_context(out: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    out.write_str("{{{reset:end}}}\n")
 }


### PR DESCRIPTION
{{{reset:begin/end}}} pair will allow symbolization to be performed on the whole stack rather than invidival frames.

This has been tested manually and verified to work.
