### PR TITLE
Bump to 0.3.69

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.69"
 authors = ["The Rust Project Developers"]
 build = "build.rs"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
To be merged after https://github.com/rust-lang/backtrace-rs/pull/559.