### PR TITLE
infer_current_exe: Avoid picking non-path from maps

### DIFF
--- a/src/symbolize/gimli/libs_dl_iterate_phdr.rs
+++ b/src/symbolize/gimli/libs_dl_iterate_phdr.rs
@@ -25,7 +25,9 @@ fn infer_current_exe(base_addr: usize) -> OsString {
             .map(|e| e.pathname())
             .cloned();
         if let Some(path) = opt_path {
-            return path;
+            if path.as_bytes()[0] as char == '/' {
+                return path;
+            }
         }
     }
     env::current_exe().map(|e| e.into()).unwrap_or_default()


### PR DESCRIPTION
Some ports are not showing paths in /proc/self/maps yet, so better make sure that we actually get a path before returning it, and fallback to current_exe() otherwise.