### PR TITLE
Adjust frame IP in SGX relative to image base

### DIFF
--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -134,6 +134,7 @@ mod sgx_no_std_image_base {
     /// Set the image base address. This is only available for Fortanix SGX
     /// target when the `std` feature is not enabled. This can be used in the
     /// standard library to set the correct base address.
+    #[doc(hidden)]
     pub fn set_image_base(base_addr: u64) {
         IMAGE_BASE.store(base_addr, SeqCst);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,12 @@ cfg_if::cfg_if! {
     }
 }
 
+cfg_if::cfg_if! {
+    if #[cfg(all(target_env = "sgx", target_vendor = "fortanix", not(feature = "std")))] {
+        pub use self::backtrace::set_image_base;
+    }
+}
+
 #[allow(dead_code)]
 struct Bomb {
     enabled: bool,

--- a/src/print.rs
+++ b/src/print.rs
@@ -219,7 +219,7 @@ impl BacktraceFrameFmt<'_, '_, '_> {
     #[allow(unused_mut)]
     fn print_raw_generic(
         &mut self,
-        mut frame_ip: *mut c_void,
+        frame_ip: *mut c_void,
         symbol_name: Option<SymbolName<'_>>,
         filename: Option<BytesOrWideString<'_>>,
         lineno: Option<u32>,
@@ -231,15 +231,6 @@ impl BacktraceFrameFmt<'_, '_, '_> {
             if frame_ip.is_null() {
                 return Ok(());
             }
-        }
-
-        // To reduce TCB size in Sgx enclave, we do not want to implement symbol
-        // resolution functionality.  Rather, we can print the offset of the
-        // address here, which could be later mapped to correct function.
-        #[cfg(all(feature = "std", target_env = "sgx", target_vendor = "fortanix"))]
-        {
-            let image_base = std::os::fortanix_sgx::mem::image_base();
-            frame_ip = usize::wrapping_sub(frame_ip as usize, image_base as _) as _;
         }
 
         // Print the index of the frame as well as the optional instruction

--- a/tests/sgx-image-base.rs
+++ b/tests/sgx-image-base.rs
@@ -1,0 +1,56 @@
+#![cfg(all(target_env = "sgx", target_vendor = "fortanix"))]
+#![feature(sgx_platform)]
+
+#[cfg(feature = "std")]
+#[test]
+fn sgx_image_base_with_std() {
+    use backtrace::trace;
+
+    let image_base = std::os::fortanix_sgx::mem::image_base();
+
+    let mut frame_ips = Vec::new();
+    trace(|frame| {
+        frame_ips.push(frame.ip());
+        true
+    });
+
+    assert!(frame_ips.len() > 0);
+    for ip in frame_ips {
+        let ip: u64 = ip as _;
+        assert!(ip < image_base);
+    }
+}
+
+#[cfg(not(feature = "std"))]
+#[test]
+fn sgx_image_base_no_std() {
+    use backtrace::trace_unsynchronized;
+
+    fn guess_image_base() -> u64 {
+        let mut top_frame_ip = None;
+        unsafe {
+            trace_unsynchronized(|frame| {
+                top_frame_ip = Some(frame.ip());
+                false
+            });
+        }
+        top_frame_ip.unwrap() as u64 & 0xFFFFFF000000
+    }
+
+    let image_base = guess_image_base();
+    backtrace::set_image_base(image_base);
+
+    let mut frame_ips = Vec::new();
+    unsafe {
+        trace_unsynchronized(|frame| {
+            frame_ips.push(frame.ip());
+            true
+        });
+    }
+
+    assert!(frame_ips.len() > 0);
+    for ip in frame_ips {
+        let ip: u64 = ip as _;
+        assert!(ip < image_base);
+    }
+}

--- a/tests/sgx-image-base.rs
+++ b/tests/sgx-image-base.rs
@@ -38,7 +38,7 @@ fn sgx_image_base_no_std() {
     }
 
     let image_base = guess_image_base();
-    backtrace::set_image_base(image_base);
+    backtrace::set_image_base(image_base as _);
 
     let mut frame_ips = Vec::new();
     unsafe {


### PR DESCRIPTION
The backtraces printed by `panic!` are broken in SGX, this PR is a prerequisite for fixing the issue in the standard library.

The SGX-only API added in this PR (`backtrace::set_image_base`) enables the standard library to set the correct image base address before calling `trace_unsynchronized` here: https://github.com/rust-lang/rust/blob/1.72.1/library/std/src/sys_common/backtrace.rs#L65.

cc @jethrogb