### PR TITLE
Enable calling build.rs externally v2

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,17 +11,27 @@ pub fn main() {
     }
 }
 
+// Used to detect the value of the `__ANDROID_API__`
+// builtin #define
+const MARKER: &str = "BACKTRACE_RS_ANDROID_APIVERSION";
+const ANDROID_API_C: &str = "
+BACKTRACE_RS_ANDROID_APIVERSION __ANDROID_API__
+";
+
 fn build_android() {
-    // Resolve `src/android-api.c` relative to this file.
+    // Create `android-api.c` on demand.
     // Required to support calling this from the `std` build script.
-    let android_api_c = Path::new(file!())
-        .parent()
-        .unwrap()
-        .join("src/android-api.c");
-    let expansion = match cc::Build::new().file(android_api_c).try_expand() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let android_api_c = Path::new(&out_dir).join("android-api.c");
+    std::fs::write(&android_api_c, ANDROID_API_C).unwrap();
+
+    let expansion = match cc::Build::new().file(&android_api_c).try_expand() {
         Ok(result) => result,
         Err(e) => {
-            println!("failed to run C compiler: {}", e);
+            eprintln!(
+                "warning: android version detection failed while running C compiler: {}",
+                e
+            );
             return;
         }
     };
@@ -29,13 +39,12 @@ fn build_android() {
         Ok(s) => s,
         Err(_) => return,
     };
-    println!("expanded android version detection:\n{}", expansion);
-    let marker = "APIVERSION";
-    let i = match expansion.find(marker) {
+    eprintln!("expanded android version detection:\n{}", expansion);
+    let i = match expansion.find(MARKER) {
         Some(i) => i,
         None => return,
     };
-    let version = match expansion[i + marker.len() + 1..].split_whitespace().next() {
+    let version = match expansion[i + MARKER.len() + 1..].split_whitespace().next() {
         Some(s) => s,
         None => return,
     };

--- a/src/android-api.c
+++ b/src/android-api.c
@@ -1,4 +1,0 @@
-// Used from the build script to detect the value of the `__ANDROID_API__`
-// builtin #define
-
-APIVERSION __ANDROID_API__


### PR DESCRIPTION
Addresses the issue found here: https://github.com/rust-lang/cc-rs/pull/705#issuecomment-1745754154

This time we write the file into OUT_DIR, then there's no CWD issues. Make sure to check the android CI runs for those CC warnings.