### PR TITLE
Fix i686-pc-windows-gnu missing dbghelp module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,11 @@ mod lock {
     }
 }
 
-#[cfg(all(windows, target_env = "msvc", not(target_vendor = "uwp")))]
+#[cfg(all(
+    windows,
+    any(target_env = "msvc", all(target_env = "gnu", target_arch = "x86")),
+    not(target_vendor = "uwp")
+))]
 mod dbghelp;
 #[cfg(windows)]
 mod windows;


### PR DESCRIPTION
`i686-pc-windows-gnu` also needs to use the `dbghelp` module so it should be declared when building for that target. 

Discovered when attempting to update the backtrace module in rust-lang/rust. 