### PR TITLE
Fix unused_imports warning on latest nightly

### DIFF
--- a/crates/as-if-std/src/lib.rs
+++ b/crates/as-if-std/src/lib.rs
@@ -9,6 +9,7 @@ extern crate alloc;
 
 // We want to `pub use std::*` in the root but we don't want `std` available in
 // the root namespace, so do this in a funky inner module.
+#[allow(unused_imports)]
 mod __internal {
     extern crate std;
     pub use std::*;


### PR DESCRIPTION
This was causing CI to fail.

Fixes #574 (hopefully)