### PR TITLE
Fix panic in backtrace symbolication on win7

### DIFF
--- a/src/dbghelp.rs
+++ b/src/dbghelp.rs
@@ -34,8 +34,8 @@ use core::ptr;
 mod dbghelp {
     use crate::windows::*;
     pub use winapi::um::dbghelp::{
-        StackWalk64, StackWalkEx, SymFunctionTableAccess64, SymGetModuleBase64, SymGetOptions,
-        SymInitializeW, SymSetOptions,
+        StackWalk64, StackWalkEx, SymFromAddrW, SymFunctionTableAccess64, SymGetLineFromAddrW64,
+        SymGetModuleBase64, SymGetOptions, SymInitializeW, SymSetOptions,
     };
 
     extern "system" {
@@ -232,6 +232,18 @@ dbghelp! {
             CurAddress: DWORD64,
             CurContext: LPDWORD,
             CurFrameIndex: LPDWORD
+        ) -> BOOL;
+        fn SymFromAddrW(
+            hProcess: HANDLE,
+            Address: DWORD64,
+            Displacement: PDWORD64,
+            Symbol: PSYMBOL_INFOW
+        ) -> BOOL;
+        fn SymGetLineFromAddrW64(
+            hProcess: HANDLE,
+            dwAddr: DWORD64,
+            pdwDisplacement: PDWORD,
+            Line: PIMAGEHLP_LINEW64
         ) -> BOOL;
     }
 }


### PR DESCRIPTION
Since https://github.com/rust-lang/backtrace-rs/pull/569 was merged, symbolication of backtraces would panic on Windows 7, due to using symbols that do not exist in the version of dbghelp.dll that ships there (Windows 7 ships with dbghelp.dll version 6.1, but the symbols were only added in version 6.2).

This commit checks for the presence of the newer symbols, and if they are not found, falls back to the old resolution method.

Fixes #577 