### PR TITLE
"Fix" clippy::correctness

### DIFF
--- a/src/symbolize/gimli/stash.rs
+++ b/src/symbolize/gimli/stash.rs
@@ -22,6 +22,7 @@ impl Stash {
 
     /// Allocates a buffer of the specified size and returns a mutable reference
     /// to it.
+    #[allow(clippy::mut_from_ref)] // This is an arena allocator.
     pub fn allocate(&self, size: usize) -> &mut [u8] {
         // SAFETY: this is the only function that ever constructs a mutable
         // reference to `self.buffers`.

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -58,6 +58,7 @@ use rustc_demangle::{try_demangle, Demangle};
 /// }
 /// ```
 #[cfg(feature = "std")]
+#[allow(clippy::not_unsafe_ptr_arg_deref)] // The unsafe does not come from ptr deref
 pub fn resolve<F: FnMut(&Symbol)>(addr: *mut c_void, cb: F) {
     let _guard = crate::lock::lock();
     unsafe { resolve_unsynchronized(addr, cb) }


### PR DESCRIPTION
For https://github.com/rust-lang/compiler-team/issues/709