### PR TITLE
Fix rustc-serialize build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,9 +157,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "serde"


### PR DESCRIPTION
For reasons unknown to me, this crate still supports rustc-serialize. While that should probably be changed at some point, there's an update available, so fixing the build is easy.