### PR TITLE
ignore clippy lints in `symbolize/gimli/stash.rs`

### DIFF
--- a/src/symbolize/gimli/stash.rs
+++ b/src/symbolize/gimli/stash.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 // only used on Linux right now, so allow dead code elsewhere
 #![cfg_attr(not(target_os = "linux"), allow(dead_code))]
 


### PR DESCRIPTION
This is a blocker for https://github.com/rust-lang/rust/pull/121543