### PR TITLE
Add support for arm64ec

### DIFF
--- a/src/backtrace/dbghelp.rs
+++ b/src/backtrace/dbghelp.rs
@@ -60,7 +60,7 @@ impl Frame {
 #[repr(C, align(16))] // required by `CONTEXT`, is a FIXME in winapi right now
 struct MyContext(CONTEXT);
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "arm64ec"))]
 impl MyContext {
     #[inline(always)]
     fn ip(&self) -> DWORD64 {
@@ -122,7 +122,11 @@ impl MyContext {
     }
 }
 
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "arm64ec"
+))]
 #[inline(always)]
 pub unsafe fn trace(cb: &mut dyn FnMut(&super::Frame) -> bool) {
     use core::ptr;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -447,7 +447,11 @@ ffi! {
     }
 }
 
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "arm64ec"
+))]
 ffi! {
     #[link(name = "kernel32")]
     extern "system" {
@@ -594,7 +598,7 @@ ffi! {
     }
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "arm64ec"))]
 ffi! {
     #[repr(C, align(8))]
     pub struct CONTEXT {
@@ -662,7 +666,7 @@ ffi! {
 }
 
 #[repr(C)]
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "x86_64", target_arch = "arm64ec"))]
 #[derive(Copy, Clone)]
 pub struct FLOATING_SAVE_AREA {
     _Dummy: [u8; 512],


### PR DESCRIPTION
The Rust Compiler has recently added support for ARM64EC (<https://github.com/rust-lang/rust/pull/119199>), so this change adds support for ARM64EC to backtrace by using the same OS structures and functions as x64 NOT AArch64: this is because an ARM64EC binary runs within an x64 process (on an AArch64 machine), thus all the OS binaries it is interfacing with expose the x64 API.