### PR TITLE
Make sgx functions exist with cfg(miri)

### DIFF
--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -125,7 +125,7 @@ impl fmt::Debug for Frame {
     }
 }
 
-#[cfg(all(target_env = "sgx", target_vendor = "fortanix", not(miri)))]
+#[cfg(all(target_env = "sgx", target_vendor = "fortanix"))]
 mod sgx_image_base {
 
     #[cfg(not(feature = "std"))]
@@ -160,12 +160,7 @@ mod sgx_image_base {
     pub(crate) use imp::get_image_base;
 }
 
-#[cfg(all(
-    target_env = "sgx",
-    target_vendor = "fortanix",
-    not(feature = "std"),
-    not(miri)
-))]
+#[cfg(all(target_env = "sgx", target_vendor = "fortanix", not(feature = "std")))]
 pub use sgx_image_base::imp::set_image_base;
 
 cfg_if::cfg_if! {


### PR DESCRIPTION
https://github.com/rust-lang/backtrace-rs/pull/581 actually broke builds of the sgx target with Miri worse :upside_down_face: 

This time I tested this patch by applying this patch to the Rust tree and doing
```
MIRI_LIB_SRC=/home/ben/rust/library/ cargo +nightly miri setup --target=x86_64-fortanix-unknown-sgx
```