### PR TITLE
Update version of cc crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,12 +51,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ winapi = { version = "0.3.9", optional = true }
 [build-dependencies]
 # Only needed for Android, but cannot be target dependent
 # https://github.com/rust-lang/cargo/issues/4932
-cc = "1.0.67"
+cc = "1.0.90"
 
 [dev-dependencies]
 dylib-dep = { path = "crates/dylib-dep" }

--- a/crates/as-if-std/Cargo.toml
+++ b/crates/as-if-std/Cargo.toml
@@ -28,7 +28,7 @@ features = ['read_core', 'elf', 'macho', 'pe', 'xcoff', 'unaligned', 'archive']
 
 [build-dependencies]
 # Dependency of the `backtrace` crate
-cc = "1.0.67"
+cc = "1.0.90"
 
 [features]
 default = ['backtrace']


### PR DESCRIPTION
Reason:

In order to build the Windows version of the Rust toolchain for the Android platform, the following patch to the cc is crate is required to avoid incorrectly determining that we are building with the Android NDK: https://github.com/rust-lang/cc-rs/commit/57853c4bf8a89a0f4c9137eb367ac580305c6919

This patch is present in version 1.0.80 and newer versions of the cc crate. The rustc source distribution currently has 3 different versions of cc in the vendor directory, only one of which has the necessary fix.

We (the Android Rust toolchain) are currently maintaining local patches to upgrade the cc crate dependency versions, which we would like to upstream.