### PR TITLE
Don't strip std debug information

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Force frame pointers
       run: echo RUSTFLAGS="-Cforce-frame-pointers $RUSTFLAGS" >> $GITHUB_ENV
       shell: bash
-      if: matrix.rust == 'stable-i686-msvc'
+      if: contains(matrix.rust, '-i686-msvc')
 
     - run: cargo build
     - run: cargo test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,14 +26,18 @@ jobs:
             rust: stable
           - os: macos-latest
             rust: nightly
-          # Note that these are on nightly due to rust-lang/rust#63700 not being
-          # on stable yet
           - os: windows-latest
             rust: stable-x86_64-msvc
           - os: windows-latest
             rust: stable-i686-msvc
           - os: windows-latest
             rust: stable-x86_64-gnu
+          - os: windows-latest
+            rust: nightly-x86_64-msvc
+          - os: windows-latest
+            rust: nightly-i686-msvc
+          - os: windows-latest
+            rust: nightly-x86_64-gnu
     steps:
     - uses: actions/checkout@v3
       with:

--- a/crates/without_debuginfo/Cargo.toml
+++ b/crates/without_debuginfo/Cargo.toml
@@ -11,9 +11,11 @@ features = ['std']
 
 [profile.dev]
 debug = false
+strip = "debuginfo"
 
 [profile.test]
 debug = false
+strip = "debuginfo"
 
 [features]
 libbacktrace = ['backtrace/libbacktrace']


### PR DESCRIPTION
The `without_debuginfo` test relies on std still having debug info. Let's see if this fixes CI, or at least the Windows runners.