### PR TITLE
Fix CI and remove rustc-serialize

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,13 +26,18 @@ jobs:
             rust: stable
           - os: macos-latest
             rust: nightly
-          # HACK(jubilee): 1.77 broke backtraces on Windows lol
           - os: windows-latest
-            rust: 1.76.0-x86_64-msvc
+            rust: stable-x86_64-msvc
           - os: windows-latest
-            rust: 1.76.0-i686-msvc
+            rust: stable-i686-msvc
           - os: windows-latest
-            rust: 1.76.0-x86_64-gnu
+            rust: stable-x86_64-gnu
+          - os: windows-latest
+            rust: nightly-x86_64-msvc
+          - os: windows-latest
+            rust: nightly-i686-msvc
+          - os: windows-latest
+            rust: nightly-x86_64-gnu
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,6 @@ jobs:
 
     - run: cargo build
     - run: cargo test
-    - run: cargo test --features "serialize-rustc"
     - run: cargo test --features "serialize-serde"
     - run: cargo test --features "verify-winapi"
     - run: cargo test --features "cpp_demangle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,6 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "rustc-serialize",
  "serde",
  "winapi",
 ]
@@ -151,12 +150,6 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ rust-version = "1.65.0"
 [workspace]
 members = ['crates/cpp_smoke_test', 'crates/as-if-std']
 exclude = [
-   'crates/without_debuginfo',
-   'crates/macos_frames_test',
-   'crates/line-tables-only',
-   'crates/debuglink',
+  'crates/without_debuginfo',
+  'crates/macos_frames_test',
+  'crates/line-tables-only',
+  'crates/debuglink',
 ]
 
 [dependencies]
@@ -33,10 +33,11 @@ rustc-demangle = "0.1.4"
 # Optionally enable the ability to serialize a `Backtrace`, controlled through
 # the `serialize-*` features below.
 serde = { version = "1.0", optional = true, features = ['derive'] }
-rustc-serialize = { version = "0.3", optional = true }
 
 # Optionally demangle C++ frames' symbols in backtraces.
-cpp_demangle = { default-features = false, version = "0.4.0", optional = true, features = ["alloc"] }
+cpp_demangle = { default-features = false, version = "0.4.0", optional = true, features = [
+  "alloc",
+] }
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
 miniz_oxide = { version = "0.7.0", default-features = false }
@@ -71,7 +72,6 @@ std = []
 # Methods of serialization
 #
 # Various features used for enabling rustc-serialize or syntex codegen.
-serialize-rustc = ["rustc-serialize"]
 serialize-serde = ["serde"]
 
 #=======================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,6 @@
 // irrelevant as this crate is developed out-of-tree.
 #![cfg_attr(backtrace_in_libstd, allow(warnings))]
 #![cfg_attr(not(feature = "std"), allow(dead_code))]
-// We know this is deprecated, it's only here for back-compat reasons.
-#![cfg_attr(feature = "rustc-serialize", allow(deprecated))]
 
 #[cfg(feature = "std")]
 #[macro_use]

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -472,10 +472,7 @@ pub unsafe fn resolve(what: ResolveWhat<'_>, cb: &mut dyn FnMut(&super::Symbol))
         }
         if !any_frames {
             if let Some(name) = cx.object.search_symtab(addr as u64) {
-                call(Symbol::Symtab {
-                    addr: addr as *mut c_void,
-                    name,
-                });
+                call(Symbol::Symtab { name });
             }
         }
     });
@@ -491,7 +488,7 @@ pub enum Symbol<'a> {
     },
     /// Couldn't find debug information, but we found it in the symbol table of
     /// the elf executable.
-    Symtab { addr: *mut c_void, name: &'a [u8] },
+    Symtab { name: &'a [u8] },
 }
 
 impl Symbol<'_> {

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -231,18 +231,6 @@ fn many_threads() {
 }
 
 #[test]
-#[cfg(feature = "rustc-serialize")]
-fn is_rustc_serialize() {
-    extern crate rustc_serialize;
-
-    fn is_encode<T: rustc_serialize::Encodable>() {}
-    fn is_decode<T: rustc_serialize::Decodable>() {}
-
-    is_encode::<backtrace::Backtrace>();
-    is_decode::<backtrace::Backtrace>();
-}
-
-#[test]
 #[cfg(feature = "serde")]
 fn is_serde() {
     extern crate serde;


### PR DESCRIPTION
@workingjubilee I'm not clear why we weren't doing this already. It would have caught the stripping issue earlier. There's a very old comment about only testing on nightly but that's the opposite of what we were doing.

Obviously this will still currently fail CI until rustc or cargo is patched.