### PR TITLE
Use rustc from stage0 instead of stage0-sysroot

### DIFF
--- a/.github/actions/build-with-patched-std/action.yml
+++ b/.github/actions/build-with-patched-std/action.yml
@@ -41,7 +41,7 @@ runs:
         python3 x.py build library --stage 0
 
         TEMP_BUILD_OUTPUT=$(mktemp test-binary-XXXXXXXX)
-        "$RUSTC_BUILD_DIR/stage0-sysroot/bin/rustc" $RUSTC_FLAGS "${{ inputs.main-rs }}" -o "$TEMP_BUILD_OUTPUT"
+        "$RUSTC_BUILD_DIR/stage0/bin/rustc" $RUSTC_FLAGS "${{ inputs.main-rs }}" -o "$TEMP_BUILD_OUTPUT"
         BINARY_SIZE=$(stat -c '%s' "$TEMP_BUILD_OUTPUT")
         rm "$TEMP_BUILD_OUTPUT"
 

--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -6,9 +6,8 @@ name: Check binary size
 
 on:
   pull_request_target:
-    # HACK(jubilee): something broke the distributed LLVM libso and I don't know what.
-    branches: []
-#      - master
+    branches:
+      - master
 
 # Both the "measure" and "report" jobs need to know this.
 env:


### PR DESCRIPTION
It contains the right LLVM libraries.

for #600, so we can yolo-merge this.