### PR TITLE
Revert "Use rustc from stage0 instead of stage0-sysroot (rust-lang/ba…

### DIFF
--- a/.github/actions/build-with-patched-std/action.yml
+++ b/.github/actions/build-with-patched-std/action.yml
@@ -41,7 +41,7 @@ runs:
         python3 x.py build library --stage 0
 
         TEMP_BUILD_OUTPUT=$(mktemp test-binary-XXXXXXXX)
-        "$RUSTC_BUILD_DIR/stage0/bin/rustc" $RUSTC_FLAGS "${{ inputs.main-rs }}" -o "$TEMP_BUILD_OUTPUT"
+        "$RUSTC_BUILD_DIR/stage0-sysroot/bin/rustc" $RUSTC_FLAGS "${{ inputs.main-rs }}" -o "$TEMP_BUILD_OUTPUT"
         BINARY_SIZE=$(stat -c '%s' "$TEMP_BUILD_OUTPUT")
         rm "$TEMP_BUILD_OUTPUT"
 

--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -6,8 +6,9 @@ name: Check binary size
 
 on:
   pull_request_target:
-    branches:
-      - master
+    # HACK(jubilee): something broke the distributed LLVM libso and I don't know what.
+    branches: []
+#      - master
 
 # Both the "measure" and "report" jobs need to know this.
 env:


### PR DESCRIPTION
…cktrace-rs#602)"

This reverts commit c31ea5ba7ac52f5c15c65cfec7d7b5d0bcf00eed.

Don't do that, we need to use stage0-sysroot, bootstrap is just buggy. Keep it commented out until bootstrap is fixed.

https://github.com/rust-lang/backtrace-rs/pull/600#issuecomment-2016500263

r? @workingjubilee 