### PR TITLE
build.rs: canonicalize OUT_DIR

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,7 +21,7 @@ BACKTRACE_RS_ANDROID_APIVERSION __ANDROID_API__
 fn build_android() {
     // Create `android-api.c` on demand.
     // Required to support calling this from the `std` build script.
-    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let out_dir = std::fs::canonicalize(env::var_os("OUT_DIR").unwrap()).unwrap();
     let android_api_c = Path::new(&out_dir).join("android-api.c");
     std::fs::write(&android_api_c, ANDROID_API_C).unwrap();
 

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 extern crate cc;
 
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 // Must be public so the build script of `std` can call it.
 pub fn main() {
@@ -21,7 +21,8 @@ BACKTRACE_RS_ANDROID_APIVERSION __ANDROID_API__
 fn build_android() {
     // Create `android-api.c` on demand.
     // Required to support calling this from the `std` build script.
-    let out_dir = std::fs::canonicalize(env::var_os("OUT_DIR").unwrap()).unwrap();
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let out_dir = std::fs::canonicalize(&out_dir).unwrap_or(PathBuf::from(out_dir));
     let android_api_c = Path::new(&out_dir).join("android-api.c");
     std::fs::write(&android_api_c, ANDROID_API_C).unwrap();
 


### PR DESCRIPTION
Hi, I discovered a build problem when building this crate with the Bazel build system for the Android platform. 

This warning occurs:
```
Build Script Warning: clang: error: no such file or directory: 'external/crate_index__backtrace-0.3.69/src/android-api.c'
Build Script Warning: clang: error: no input files
```

The problem is due to the fact that `OUT_DIR` is a relative path, and it looks like `cc::Build:: ... .try_expand()` expects an absolute path. Maybe because it's running inside a temporary dir ? I didn't dig enough to know.

I can confirm that canonicalizing the OUT_DIR fixes my problem.  