### PR TITLE
Fix tests for rust 1.79

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,7 +199,7 @@ jobs:
       with:
         submodules: true
     - name: Install Rust
-      run: rustup update stable && rustup default stable
+      run: rustup update stable --no-self-update && rustup default stable
     - run: rustup target add ${{ matrix.target }}
     - run: cargo generate-lockfile
     - run: echo RUSTFLAGS=-Dwarnings >> $GITHUB_ENV
@@ -214,7 +214,7 @@ jobs:
       with:
         submodules: true
     - name: Install Rust
-      run: rustup update stable && rustup default stable && rustup component add rustfmt
+      run: rustup update stable --no-self-update && rustup default stable && rustup component add rustfmt
     - run: cargo fmt --all -- --check
 
   build:
@@ -233,7 +233,7 @@ jobs:
       with:
         submodules: true
     - name: Install Rust
-      run: rustup update nightly && rustup default nightly
+      run: rustup update nightly --no-self-update && rustup default nightly
     - run: rustup target add ${{ matrix.target }}
     - run: echo RUSTFLAGS=-Dwarnings >> $GITHUB_ENV
       shell: bash
@@ -254,7 +254,7 @@ jobs:
       with:
         submodules: true
     - name: Install Rust
-      run: rustup update 1.65.0 && rustup default 1.65.0
+      run: rustup update 1.65.0 --no-self-update && rustup default 1.65.0
     - run: cargo build
 
   miri:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,11 @@ jobs:
       shell: bash
       if: contains(matrix.rust, 'i686')
 
+    - name: Enable collapse_debuginfo based on version
+      run: echo RUSTFLAGS="--cfg dbginfo=\"collapsible\" $RUSTFLAGS" >> $GITHUB_ENV
+      shell: bash
+      if: contains(matrix.rust, 'nightly') || contains(matrix.rust, 'beta')
+
     - run: cargo build
     - run: cargo test
     - run: cargo test --features "serialize-serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ serialize-serde = ["serde"]
 # purposes. New code should use none of these features.
 coresymbolication = []
 dbghelp = []
+dl_iterate_phdr = []
 dladdr = []
 gimli-symbolize = []
 kernel32 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,3 +132,7 @@ harness = false
 name = "current-exe-mismatch"
 required-features = ["std"]
 harness = false
+
+[lints.rust]
+# This crate uses them pervasively
+unexpected_cfgs = "allow"

--- a/crates/as-if-std/Cargo.toml
+++ b/crates/as-if-std/Cargo.toml
@@ -33,3 +33,7 @@ cc = "1.0.90"
 [features]
 default = ['backtrace']
 backtrace = ['addr2line', 'miniz_oxide', 'object']
+std = []
+
+[lints.rust]
+unexpected_cfgs = "allow"

--- a/tests/accuracy/main.rs
+++ b/tests/accuracy/main.rs
@@ -1,3 +1,4 @@
+#![cfg(dbginfo = "collapsible")]
 mod auxiliary;
 
 macro_rules! pos {
@@ -6,6 +7,7 @@ macro_rules! pos {
     };
 }
 
+#[collapse_debuginfo(yes)]
 macro_rules! check {
     ($($pos:expr),*) => ({
         verify(&[$($pos,)* pos!()]);


### PR DESCRIPTION
- Fix the accuracy test for `collapse_debuginfo`
- Fix a couple of unexpected_cfgs warnings about Cargo features
- Silence the rest, ain't nobody got time for all that shit
- Use `rustup update --no-self-update` consistently to avoid spurious CI errors