### PR TITLE
Bump rustc-demangle version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ exclude = [
 
 [dependencies]
 cfg-if = "1.0"
-rustc-demangle = "0.1.4"
+rustc-demangle = "0.1.24"
 
 # Optionally enable the ability to serialize a `Backtrace`, controlled through
 # the `serialize-serde` feature below.


### PR DESCRIPTION
Update rustc-demangle to the latest version. This might soon be needed to correctly render `f16` and `f128` (see https://github.com/rust-lang/rust/pull/123816). rust-lang/rust [already uses that version](https://github.com/rust-lang/rust/blob/58426f4a5b69d10db1b0ffa017bac25f1b2e801e/Cargo.lock#L3441).