### PR TITLE
Test with lld-compatible args

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,11 +80,7 @@ jobs:
     - run: cargo test
       if: contains(matrix.os, 'ubuntu')
       env:
-        RUSTFLAGS: "-C link-arg=-Wl,--compress-debug-sections=zlib-gabi"
-    - run: cargo test
-      if: contains(matrix.os, 'ubuntu')
-      env:
-        RUSTFLAGS: "-C link-arg=-Wl,--compress-debug-sections=zlib-gnu"
+        RUSTFLAGS: "-C link-arg=-Wl,--compress-debug-sections=zlib"
 
     # Test that, on macOS, packed/unpacked debuginfo both work
     - run: cargo clean && cargo test


### PR DESCRIPTION
Rust has switched to using rust-lld by default on Linux, and it does not support the zlib-gnu or zlib-gabi arguments for --compress-debug-sections! Not surprising. It's... not GNU. Compensate for this by using zlib, which everyone supports.