### PR TITLE
Update some comments

### DIFF
--- a/src/backtrace/dbghelp32.rs
+++ b/src/backtrace/dbghelp32.rs
@@ -1,6 +1,6 @@
-//! Backtrace strategy for MSVC platforms.
+//! Backtrace strategy for Windows platforms.
 //!
-//! This module contains the ability to generate a backtrace on MSVC using one
+//! This module contains the ability to generate a backtrace on Windows using one
 //! of two possible methods. The `StackWalkEx` function is primarily used if
 //! possible, but not all systems have that. Failing that the `StackWalk64`
 //! function is used instead. Note that `StackWalkEx` is favored because it

--- a/src/backtrace/dbghelp64.rs
+++ b/src/backtrace/dbghelp64.rs
@@ -1,6 +1,6 @@
-//! Backtrace strategy for MSVC `x86_64` and `aarch64` platforms.
+//! Backtrace strategy for Windows `x86_64` and `aarch64` platforms.
 //!
-//! This module contains the ability to capture a backtrace on MSVC using
+//! This module contains the ability to capture a backtrace on Windows using
 //!  `RtlVirtualUnwind` to walk the stack one frame at a time. This function is much faster than using
 //! `dbghelp!StackWalk*` because it does not load debug info to report inlined frames.
 //! We still report inlined frames during symbolization by consulting the appropriate


### PR DESCRIPTION
I've replaced the comment about MSVC in src/backtrace/dbghelp*.rs as the same code is used for windows-gnu, see https://github.com/rust-lang/backtrace-rs/blob/5e05efa87905fb5b351a2bc5644d60c57d6d9327/src/backtrace/mod.rs#L169-L199