### PR TITLE
test cleanup for nightly

### DIFF
--- a/src/dbghelp.rs
+++ b/src/dbghelp.rs
@@ -114,9 +114,8 @@ macro_rules! dbghelp {
             })*
 
             pub fn dbghelp(&self) -> *mut Dbghelp {
-                unsafe {
-                    ptr::addr_of_mut!(DBGHELP)
-                }
+                #[allow(unused_unsafe)]
+                unsafe { ptr::addr_of_mut!(DBGHELP) }
             }
         }
     )

--- a/tests/concurrent-panics.rs
+++ b/tests/concurrent-panics.rs
@@ -45,9 +45,9 @@ fn parent() {
 fn child() {
     let done = Arc::new(AtomicBool::new(false));
     let done2 = done.clone();
-    let a = thread::spawn(move || {
-        while !done2.load(SeqCst) {
-            format!("{:?}", backtrace::Backtrace::new());
+    let a = thread::spawn(move || loop {
+        if done2.load(SeqCst) {
+            break format!("{:?}", backtrace::Backtrace::new());
         }
     });
 

--- a/tests/skip_inner_frames.rs
+++ b/tests/skip_inner_frames.rs
@@ -1,4 +1,5 @@
 use backtrace::Backtrace;
+use core::ffi::c_void;
 
 // This test only works on platforms which have a working `symbol_address`
 // function for frames which reports the starting address of a symbol. As a
@@ -12,6 +13,7 @@ const ENABLED: bool = cfg!(all(
 ));
 
 #[test]
+#[inline(never)]
 fn backtrace_new_unresolved_should_start_with_call_site_trace() {
     if !ENABLED {
         return;
@@ -22,13 +24,14 @@ fn backtrace_new_unresolved_should_start_with_call_site_trace() {
 
     assert!(!b.frames().is_empty());
 
-    let this_ip = backtrace_new_unresolved_should_start_with_call_site_trace as usize;
-    println!("this_ip: {:?}", this_ip as *const usize);
-    let frame_ip = b.frames().first().unwrap().symbol_address() as usize;
+    let this_ip = backtrace_new_unresolved_should_start_with_call_site_trace as *mut c_void;
+    println!("this_ip: {:p}", this_ip);
+    let frame_ip = b.frames().first().unwrap().symbol_address();
     assert_eq!(this_ip, frame_ip);
 }
 
 #[test]
+#[inline(never)]
 fn backtrace_new_should_start_with_call_site_trace() {
     if !ENABLED {
         return;
@@ -38,7 +41,7 @@ fn backtrace_new_should_start_with_call_site_trace() {
 
     assert!(!b.frames().is_empty());
 
-    let this_ip = backtrace_new_should_start_with_call_site_trace as usize;
-    let frame_ip = b.frames().first().unwrap().symbol_address() as usize;
+    let this_ip = backtrace_new_should_start_with_call_site_trace as *mut c_void;
+    let frame_ip = b.frames().first().unwrap().symbol_address();
     assert_eq!(this_ip, frame_ip);
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,8 +1,9 @@
 use backtrace::Frame;
+use core::ffi::c_void;
 use std::ptr;
 use std::thread;
 
-fn get_actual_fn_pointer(fp: usize) -> usize {
+fn get_actual_fn_pointer(fp: *mut c_void) -> *mut c_void {
     // On AIX, the function name references a function descriptor.
     // A function descriptor consists of (See https://reviews.llvm.org/D62532)
     // * The address of the entry point of the function.
@@ -15,17 +16,18 @@ fn get_actual_fn_pointer(fp: usize) -> usize {
     // https://www.ibm.com/docs/en/aix/7.2?topic=program-understanding-programming-toc
     if cfg!(target_os = "aix") {
         unsafe {
-            let actual_fn_entry = *(fp as *const usize);
+            let actual_fn_entry = *(fp as *const *mut c_void);
             actual_fn_entry
         }
     } else {
-        fp
+        fp as *mut c_void
     }
 }
 
 #[test]
 // FIXME: shouldn't ignore this test on i686-msvc, unsure why it's failing
 #[cfg_attr(all(target_arch = "x86", target_env = "msvc"), ignore)]
+#[inline(never)]
 #[rustfmt::skip] // we care about line numbers here
 fn smoke_test_frames() {
     frame_1(line!());
@@ -42,10 +44,10 @@ fn smoke_test_frames() {
         // Various platforms have various bits of weirdness about their
         // backtraces. To find a good starting spot let's search through the
         // frames
-        let target = get_actual_fn_pointer(frame_4 as usize);
+        let target = get_actual_fn_pointer(frame_4 as *mut c_void);
         let offset = v
             .iter()
-            .map(|frame| frame.symbol_address() as usize)
+            .map(|frame| frame.symbol_address())
             .enumerate()
             .filter_map(|(i, sym)| {
                 if sym >= target {
@@ -61,7 +63,7 @@ fn smoke_test_frames() {
 
         assert_frame(
             frames.next().unwrap(),
-            get_actual_fn_pointer(frame_4 as usize),
+            get_actual_fn_pointer(frame_4 as *mut c_void) as usize,
             "frame_4",
             "tests/smoke.rs",
             start_line + 6,
@@ -69,7 +71,7 @@ fn smoke_test_frames() {
         );
         assert_frame(
             frames.next().unwrap(),
-            get_actual_fn_pointer(frame_3 as usize),
+            get_actual_fn_pointer(frame_3 as *mut c_void) as usize,
             "frame_3",
             "tests/smoke.rs",
             start_line + 3,
@@ -77,7 +79,7 @@ fn smoke_test_frames() {
         );
         assert_frame(
             frames.next().unwrap(),
-            get_actual_fn_pointer(frame_2 as usize),
+            get_actual_fn_pointer(frame_2 as *mut c_void) as usize,
             "frame_2",
             "tests/smoke.rs",
             start_line + 2,
@@ -85,7 +87,7 @@ fn smoke_test_frames() {
         );
         assert_frame(
             frames.next().unwrap(),
-            get_actual_fn_pointer(frame_1 as usize),
+            get_actual_fn_pointer(frame_1 as *mut c_void) as usize,
             "frame_1",
             "tests/smoke.rs",
             start_line + 1,
@@ -93,7 +95,7 @@ fn smoke_test_frames() {
         );
         assert_frame(
             frames.next().unwrap(),
-            get_actual_fn_pointer(smoke_test_frames as usize),
+            get_actual_fn_pointer(smoke_test_frames as *mut c_void) as usize,
             "smoke_test_frames",
             "",
             0,
@@ -249,11 +251,11 @@ fn sp_smoke_test() {
     return;
 
     #[inline(never)]
-    fn recursive_stack_references(refs: &mut Vec<usize>) {
+    fn recursive_stack_references(refs: &mut Vec<*mut c_void>) {
         assert!(refs.len() < 5);
 
-        let x = refs.len();
-        refs.push(ptr::addr_of!(x) as usize);
+        let mut x = refs.len();
+        refs.push(ptr::addr_of_mut!(x).cast());
 
         if refs.len() < 5 {
             recursive_stack_references(refs);
@@ -271,7 +273,7 @@ fn sp_smoke_test() {
     // mangled names.
 
     fn make_trace_closure<'a>(
-        refs: &'a mut Vec<usize>,
+        refs: &'a mut Vec<*mut c_void>,
     ) -> impl FnMut(&backtrace::Frame) -> bool + 'a {
         let mut child_sp = None;
         let mut child_ref = None;
@@ -289,9 +291,9 @@ fn sp_smoke_test() {
                         })
             });
 
-            let sp = frame.sp() as usize;
-            eprintln!("sp  = {:p}", sp as *const u8);
-            if sp == 0 {
+            let sp = frame.sp();
+            eprintln!("sp  = {sp:p}");
+            if sp as usize == 0 {
                 // If the SP is null, then we don't have an implementation for
                 // getting the SP on this target. Just keep walking the stack,
                 // but don't make our assertions about the on-stack pointers and
@@ -306,8 +308,8 @@ fn sp_smoke_test() {
 
             if is_recursive_stack_references {
                 let r = refs.pop().unwrap();
-                eprintln!("ref = {:p}", r as *const u8);
-                if sp != 0 {
+                eprintln!("ref = {:p}", r);
+                if sp as usize != 0 {
                     assert!(r > sp);
                     if let Some(child_ref) = child_ref {
                         assert!(sp >= child_ref);


### PR DESCRIPTION
A collage of random bugfixes.

- `format!` now has `#[must_use]`: https://github.com/rust-lang/rust/pull/127355
- miri randomizes inlineable fn addrs: https://github.com/rust-lang/rust/pull/123781
- my own petard: https://github.com/rust-lang/rust/pull/125834
- some permissive provenance warnings became louder and it's easier to just start fixing the provenance issues throughout the API than to try to wish them away, so we introduce `TracePtr` internally to help with this.