### PR TITLE
Retry downloading the Android NDK if it fails

### DIFF
--- a/ci/android-ndk.sh
+++ b/ci/android-ndk.sh
@@ -5,7 +5,7 @@ ANDROID_NDK_ARCHIVE=android-ndk-r25b-linux.zip
 
 mkdir /android-toolchain
 cd /android-toolchain
-curl -fO $ANDROID_NDK_URL/$ANDROID_NDK_ARCHIVE
+curl --retry 20 -fO $ANDROID_NDK_URL/$ANDROID_NDK_ARCHIVE
 unzip -q $ANDROID_NDK_ARCHIVE
 rm $ANDROID_NDK_ARCHIVE
 mv android-ndk-* ndk


### PR DESCRIPTION
This should hopefully help avoid problems like this: https://github.com/rust-lang/backtrace-rs/actions/runs/10199897506/job/28218129515

