### PR TITLE
Add QNX NTO platform support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ cpp_demangle = { default-features = false, version = "0.4.0", optional = true, f
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
 miniz_oxide = { version = "0.7.0", default-features = false }
 addr2line = { version = "0.24.0", default-features = false }
-libc = { version = "0.2.146", default-features = false }
+libc = { version = "0.2.156", default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies.object]
 version = "0.36.0"

--- a/crates/as-if-std/Cargo.toml
+++ b/crates/as-if-std/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 [dependencies]
 cfg-if = "1.0"
 rustc-demangle = "0.1.21"
-libc = { version = "0.2.146", default-features = false }
+libc = { version = "0.2.156", default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
 miniz_oxide = { version = "0.7.0", optional = true, default-features = false }

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -176,7 +176,6 @@ cfg_if::cfg_if! {
                 unix,
                 not(target_os = "emscripten"),
                 not(all(target_os = "ios", target_arch = "arm")),
-                not(all(target_os = "nto", target_env = "nto70")),
             ),
             all(
                 target_env = "sgx",

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -224,6 +224,7 @@ cfg_if::cfg_if! {
             target_os = "hurd",
             target_os = "openbsd",
             target_os = "netbsd",
+            target_os = "nto",
             target_os = "android",
         ),
         not(target_env = "uclibc"),


### PR DESCRIPTION
Part of adding [aarch64-unknown-nto-qnx700](https://github.com/rust-lang/rust/pull/127897) support to Rust.  This will resolve the following failing unit tests:

```
[ui] tests/ui/backtrace/backtrace.rs
[ui] tests/ui/backtrace/dylib-dep.rs
[ui] tests/ui/backtrace/line-tables-only.rs
[ui] tests/ui/backtrace/std-backtrace.rs
[ui] tests/ui/panics/issue-47429-short-backtraces.rs#legacy
[ui] tests/ui/panics/issue-47429-short-backtraces.rs#v0
[ui] tests/ui/panics/runtime-switch.rs#legacy
[ui] tests/ui/panics/runtime-switch.rs#v0
[ui] tests/ui/panics/short-ice-remove-middle-frames-2.rs
[ui] tests/ui/panics/short-ice-remove-middle-frames.rs
[ui] tests/ui/runtime/backtrace-debuginfo.rs
```