### PR TITLE
Apply some of the `cargo clippy` suggestions

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::from_over_into)]
+
 #[cfg(feature = "serde")]
 use crate::resolve;
 use crate::PrintFmt;
@@ -351,7 +353,7 @@ impl From<crate::Frame> for BacktraceFrame {
     }
 }
 
-// we don't want implementing `impl From<Backtrace> for Vec<BacktraceFrame>` on purpose,
+// we don't want to implement `impl From<Backtrace> for Vec<BacktraceFrame>` on purpose,
 // because "... additional directions for Vec<T> can weaken type inference ..."
 // more information on https://github.com/rust-lang/backtrace-rs/pull/526
 impl Into<Vec<BacktraceFrame>> for Backtrace {
@@ -452,7 +454,7 @@ impl BacktraceSymbol {
     /// This function requires the `std` feature of the `backtrace` crate to be
     /// enabled, and the `std` feature is enabled by default.
     pub fn filename(&self) -> Option<&Path> {
-        self.filename.as_ref().map(|p| &**p)
+        self.filename.as_deref()
     }
 
     /// Same as `Symbol::lineno`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,26 +18,24 @@
 //! Next:
 //!
 //! ```
-//! fn main() {
 //! # // Unsafe here so test passes on no_std.
 //! # #[cfg(feature = "std")] {
-//!     backtrace::trace(|frame| {
-//!         let ip = frame.ip();
-//!         let symbol_address = frame.symbol_address();
+//! backtrace::trace(|frame| {
+//!     let ip = frame.ip();
+//!     let symbol_address = frame.symbol_address();
 //!
-//!         // Resolve this instruction pointer to a symbol name
-//!         backtrace::resolve_frame(frame, |symbol| {
-//!             if let Some(name) = symbol.name() {
-//!                 // ...
-//!             }
-//!             if let Some(filename) = symbol.filename() {
-//!                 // ...
-//!             }
-//!         });
-//!
-//!         true // keep going to the next frame
+//!     // Resolve this instruction pointer to a symbol name
+//!     backtrace::resolve_frame(frame, |symbol| {
+//!         if let Some(name) = symbol.name() {
+//!             // ...
+//!         }
+//!         if let Some(filename) = symbol.filename() {
+//!             // ...
+//!         }
 //!     });
-//! }
+//!
+//!     true // keep going to the next frame
+//! });
 //! # }
 //! ```
 //!

--- a/src/print.rs
+++ b/src/print.rs
@@ -288,7 +288,7 @@ impl BacktraceFrameFmt<'_, '_, '_> {
             write!(self.fmt.fmt, ":{colno}")?;
         }
 
-        write!(self.fmt.fmt, "\n")?;
+        writeln!(self.fmt.fmt)?;
         Ok(())
     }
 

--- a/src/print/fuchsia.rs
+++ b/src/print/fuchsia.rs
@@ -196,7 +196,7 @@ impl<'a> Iterator for NoteIter<'a> {
     type Item = Note<'a>;
     fn next(&mut self) -> Option<Self::Item> {
         // Check if we've reached the end.
-        if self.base.len() == 0 || self.error {
+        if self.base.is_empty() || self.error {
             return None;
         }
         // We transmute out an nhdr but we carefully consider the resulting

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -12,7 +12,6 @@ use super::SymbolName;
 use addr2line::gimli;
 use core::convert::TryInto;
 use core::mem;
-use core::u32;
 use libc::c_void;
 use mystd::ffi::OsString;
 use mystd::fs::File;
@@ -335,7 +334,7 @@ impl Cache {
         // never happen, and symbolicating backtraces would be ssssllllooooowwww.
         static mut MAPPINGS_CACHE: Option<Cache> = None;
 
-        f(MAPPINGS_CACHE.get_or_insert_with(|| Cache::new()))
+        f(MAPPINGS_CACHE.get_or_insert_with(Cache::new))
     }
 
     fn avma_to_svma(&self, addr: *const u8) -> Option<(usize, *const u8)> {

--- a/src/symbolize/gimli/elf.rs
+++ b/src/symbolize/gimli/elf.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::useless_conversion)]
+
 use super::mystd::ffi::{OsStr, OsString};
 use super::mystd::fs;
 use super::mystd::os::unix::ffi::{OsStrExt, OsStringExt};
@@ -21,7 +23,7 @@ impl Mapping {
     pub fn new(path: &Path) -> Option<Mapping> {
         let map = super::mmap(path)?;
         Mapping::mk_or_other(map, |map, stash| {
-            let object = Object::parse(&map)?;
+            let object = Object::parse(map)?;
 
             // Try to locate an external debug file using the build ID.
             if let Some(path_debug) = object.build_id().and_then(locate_build_id) {
@@ -47,7 +49,7 @@ impl Mapping {
     fn new_debug(original_path: &Path, path: PathBuf, crc: Option<u32>) -> Option<Mapping> {
         let map = super::mmap(&path)?;
         Mapping::mk(map, |map, stash| {
-            let object = Object::parse(&map)?;
+            let object = Object::parse(map)?;
 
             if let Some(_crc) = crc {
                 // TODO: check crc
@@ -224,7 +226,7 @@ impl<'a> Object<'a> {
             .map(|(_index, section)| section)
     }
 
-    pub fn search_symtab<'b>(&'b self, addr: u64) -> Option<&'b [u8]> {
+    pub fn search_symtab(&self, addr: u64) -> Option<&[u8]> {
         // Same sort of binary search as Windows above
         let i = match self.syms.binary_search_by_key(&addr, |sym| sym.address) {
             Ok(i) => i,

--- a/src/symbolize/gimli/libs_dl_iterate_phdr.rs
+++ b/src/symbolize/gimli/libs_dl_iterate_phdr.rs
@@ -14,7 +14,7 @@ pub(super) fn native_libraries() -> Vec<Library> {
     unsafe {
         libc::dl_iterate_phdr(Some(callback), core::ptr::addr_of_mut!(ret).cast());
     }
-    return ret;
+    ret
 }
 
 fn infer_current_exe(base_addr: usize) -> OsString {
@@ -65,8 +65,8 @@ unsafe extern "C" fn callback(
         segments: headers
             .iter()
             .map(|header| LibrarySegment {
-                len: (*header).p_memsz as usize,
-                stated_virtual_memory_address: (*header).p_vaddr as usize,
+                len: header.p_memsz as usize,
+                stated_virtual_memory_address: header.p_vaddr as usize,
             })
             .collect(),
         bias: info.dlpi_addr as usize,

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -63,7 +63,7 @@ pub fn resolve<F: FnMut(&Symbol)>(addr: *mut c_void, cb: F) {
     unsafe { resolve_unsynchronized(addr, cb) }
 }
 
-/// Resolve a previously capture frame to a symbol, passing the symbol to the
+/// Resolve a previously captured frame to a symbol, passing the symbol to the
 /// specified closure.
 ///
 /// This function performs the same function as `resolve` except that it takes a

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,9 +33,9 @@ impl<'a> BytesOrWideString<'a> {
     pub fn to_str_lossy(&self) -> Cow<'a, str> {
         use self::BytesOrWideString::*;
 
-        match self {
-            &Bytes(slice) => String::from_utf8_lossy(slice),
-            &Wide(wide) => Cow::Owned(String::from_utf16_lossy(wide)),
+        match *self {
+            Bytes(slice) => String::from_utf8_lossy(slice),
+            Wide(wide) => Cow::Owned(String::from_utf16_lossy(wide)),
         }
     }
 

--- a/tests/skip_inner_frames.rs
+++ b/tests/skip_inner_frames.rs
@@ -44,4 +44,8 @@ fn backtrace_new_should_start_with_call_site_trace() {
     let this_ip = backtrace_new_should_start_with_call_site_trace as *mut c_void;
     let frame_ip = b.frames().first().unwrap().symbol_address();
     assert_eq!(this_ip, frame_ip);
+
+    let trace = format!("{b:?}");
+    // FIXME: need more stacktrace content tests
+    assert!(trace.ends_with("\n"));
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -190,20 +190,20 @@ fn smoke_test_frames() {
                 );
             }
             if expected_line != 0 {
-                assert!(
-                    line == expected_line,
-                    "bad line number on frame for `{expected_name}`: {line} != {expected_line}"
-                );
+                assert_eq!(
+                    line,
+                    expected_line,
+                    "bad line number on frame for `{expected_name}`: {line} != {expected_line}");
             }
 
             // dbghelp on MSVC doesn't support column numbers
             if !cfg!(target_env = "msvc") {
                 let col = col.expect("didn't find a column number");
                 if expected_col != 0 {
-                    assert!(
-                        col == expected_col,
-                        "bad column number on frame for `{expected_name}`: {col} != {expected_col}",
-                    );
+                    assert_eq!(
+                        col,
+                        expected_col,
+                        "bad column number on frame for `{expected_name}`: {col} != {expected_col}");
                 }
             }
         }


### PR DESCRIPTION
As @workingjubilee [mentioned](https://github.com/rust-lang/backtrace-rs/pull/626#issuecomment-2134245457), `no one is really paying for professional maintenance of backtrace-rs`, so might as well try to do some volunteer upkeep. Just to keep things tidy.

Note that the code does not seem to have had `cargo fmt` run in a while, but I don't want to do it as part of code-changing PR.

The `enum backtrace::print::PrintFmt {}` seem to be requiring `#[non_exhaustive]`, but that may result in some breaking changes?  Not certain how this should be handled, and probably in a separate PR.
