### PR TITLE
Make enum `print::PrintFmt` non-exhaustive

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -24,13 +24,12 @@ pub struct BacktraceFmt<'a, 'b> {
 
 /// The styles of printing that we can print
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum PrintFmt {
     /// Prints a terser backtrace which ideally only contains relevant information
     Short,
     /// Prints a backtrace that contains all possible information
     Full,
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 impl<'a, 'b> BacktraceFmt<'a, 'b> {
@@ -254,7 +253,7 @@ impl BacktraceFrameFmt<'_, '_, '_> {
         match (symbol_name, &self.fmt.format) {
             (Some(name), PrintFmt::Short) => write!(self.fmt.fmt, "{name:#}")?,
             (Some(name), PrintFmt::Full) => write!(self.fmt.fmt, "{name}")?,
-            (None, _) | (_, PrintFmt::__Nonexhaustive) => write!(self.fmt.fmt, "<unknown>")?,
+            (None, _) => write!(self.fmt.fmt, "<unknown>")?,
         }
         self.fmt.fmt.write_str("\n")?;
 


### PR DESCRIPTION
Per @workingjubilee [comment](https://github.com/rust-lang/backtrace-rs/pull/649#issuecomment-2266257642)