### PR TITLE
Set edition=2021 on cpp_smoke_test

### DIFF
--- a/crates/cpp_smoke_test/Cargo.toml
+++ b/crates/cpp_smoke_test/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cpp_smoke_test"
 version = "0.1.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
+edition = "2021"
 build = "build.rs"
 
 [build-dependencies]


### PR DESCRIPTION
This prevents rust compiler from giving a warning