### PR TITLE
Cut backtrace 0.3.74

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 dependencies = [
  "addr2line",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
- QNX Neutrino 7.0 support, thanks nyurik!
- Dropped really old Android support, sorry Androids! Thanks fengys!
- Made PrintFmt, which was using the `Enum::__NonExhaustiveVariant` pattern, use `#[non_exhaustive]` for real. Don't @ me if you were matching on that! Thanks nyurik.
- Moved from winapi to windows-sys, thanks CraftSpider!
- Moved from windows-bindgen to windows-targets, thanks ChrisDenton!
- A bunch of updated dependencies. Thanks everyone!
- Sorry if you were testing this code in miri! It started yelling about sussy casts. A lot. We did a bunch of internal cleanups that should make it quiet down.