### PR TITLE
Fix elided_named_lifetimes warning

### DIFF
--- a/src/symbolize/gimli/macho.rs
+++ b/src/symbolize/gimli/macho.rs
@@ -250,7 +250,7 @@ impl<'a> Object<'a> {
     /// Try to load a context for an object file.
     ///
     /// If dsymutil was not run, then the DWARF may be found in the source object files.
-    pub(super) fn search_object_map<'b>(&'b mut self, addr: u64) -> Option<(&Context<'b>, u64)> {
+    pub(super) fn search_object_map<'b>(&'b mut self, addr: u64) -> Option<(&'b Context<'b>, u64)> {
         // `object_map` contains a map from addresses to symbols and object paths.
         // Look up the address and get a mapping for the object.
         let object_map = self.object_map.as_ref()?;


### PR DESCRIPTION
New on nightly

```
warning: elided lifetime has a name
   --> src\symbolize\gimli\macho.rs:253:77
    |
253 |     pub(super) fn search_object_map<'b>(&'b mut self, addr: u64) -> Option<(&Context<'b>, u64)> {
    |                                     -- lifetime `'b` declared here          ^ this elided lifetime gets resolved as `'b`
    |
    = note: `#[warn(elided_named_lifetimes)]` on by default
```