### PR TITLE
Disable libunwind for RTEMS OS

### DIFF
--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -174,7 +174,7 @@ cfg_if::cfg_if! {
         any(
             all(
                 unix,
-                not(target_os = "emscripten"),
+                not(any(target_os = "emscripten", target_os = "rtems")),
                 not(all(target_os = "ios", target_arch = "arm")),
             ),
             all(


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/127021 we added target support for RTEMS OS.

It has a POSIX interface, so we could reuse much of the `unix` backend, but currently libunwind is not supported.

Add a `cfg` switch to disable libunwind for RTEMS.