### PR TITLE
Minor `gimli` cleanup

### DIFF
--- a/src/symbolize/gimli/coff.rs
+++ b/src/symbolize/gimli/coff.rs
@@ -1,4 +1,4 @@
-use super::mystd::fs::Path;
+use super::mystd::path::Path;
 use super::{gimli, Context, Endian, EndianSlice, Mapping, Stash};
 use alloc::sync::Arc;
 use alloc::vec::Vec;

--- a/src/symbolize/gimli/coff.rs
+++ b/src/symbolize/gimli/coff.rs
@@ -1,5 +1,7 @@
-use super::{gimli, Context, Endian, EndianSlice, Mapping, Path, Stash, Vec};
+use super::mystd::fs::Path;
+use super::{gimli, Context, Endian, EndianSlice, Mapping, Stash};
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 use core::convert::TryFrom;
 use object::pe::{ImageDosHeader, ImageSymbol};
 use object::read::coff::ImageSymbol as _;

--- a/src/symbolize/gimli/elf.rs
+++ b/src/symbolize/gimli/elf.rs
@@ -6,7 +6,7 @@ use super::mystd::os::unix::ffi::OsStrExt;
 use super::mystd::path::{Path, PathBuf};
 use super::Either;
 use super::{gimli, Context, Endian, EndianSlice, Mapping, Stash};
-use alloc::str::String;
+use alloc::string::String;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::convert::{TryFrom, TryInto};
@@ -422,8 +422,8 @@ fn debug_path_exists() -> bool {
 /// The format of build id paths is documented at:
 /// https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
 fn locate_build_id(build_id: &[u8]) -> Option<PathBuf> {
-    const BUILD_ID_PATH: &[u8] = b"/usr/lib/debug/.build-id/";
-    const BUILD_ID_SUFFIX: &[u8] = b".debug";
+    const BUILD_ID_PATH: &str = "/usr/lib/debug/.build-id/";
+    const BUILD_ID_SUFFIX: &str = ".debug";
 
     if build_id.len() < 2 {
         return None;
@@ -435,7 +435,7 @@ fn locate_build_id(build_id: &[u8]) -> Option<PathBuf> {
 
     let mut path =
         String::with_capacity(BUILD_ID_PATH.len() + BUILD_ID_SUFFIX.len() + build_id.len() * 2 + 1);
-    path.extend(BUILD_ID_PATH);
+    path.push_str(BUILD_ID_PATH);
     path.push(char::from_digit((build_id[0] >> 4) as u32, 16)?);
     path.push(char::from_digit((build_id[0] & 0xf) as u32, 16)?);
     path.push('/');
@@ -443,7 +443,7 @@ fn locate_build_id(build_id: &[u8]) -> Option<PathBuf> {
         path.push(char::from_digit((byte >> 4) as u32, 16)?);
         path.push(char::from_digit((byte & 0xf) as u32, 16)?);
     }
-    path.extend(BUILD_ID_SUFFIX);
+    path.push_str(BUILD_ID_SUFFIX);
     Some(PathBuf::from(path))
 }
 

--- a/src/symbolize/gimli/elf.rs
+++ b/src/symbolize/gimli/elf.rs
@@ -393,7 +393,7 @@ fn decompress_zstd(mut input: &[u8], mut output: &mut [u8]) -> Option<()> {
     Some(())
 }
 
-const DEBUG_PATH: &[u8] = b"/usr/lib/debug";
+const DEBUG_PATH: &str = "/usr/lib/debug";
 
 fn debug_path_exists() -> bool {
     cfg_if::cfg_if! {
@@ -403,7 +403,7 @@ fn debug_path_exists() -> bool {
 
             let mut exists = DEBUG_PATH_EXISTS.load(Ordering::Relaxed);
             if exists == 0 {
-                exists = if Path::new(OsStr::from_bytes(DEBUG_PATH)).is_dir() {
+                exists = if Path::new(DEBUG_PATH).is_dir() {
                     1
                 } else {
                     2
@@ -484,7 +484,7 @@ fn locate_debuglink(path: &Path, filename: &[u8]) -> Option<PathBuf> {
     if debug_path_exists() {
         // Try "/usr/lib/debug/parent/filename"
         f.clear();
-        f.push(OsStr::from_bytes(DEBUG_PATH));
+        f.push(DEBUG_PATH);
         f.push(parent.strip_prefix("/").unwrap());
         f.push(filename);
         if f.is_file() {

--- a/src/symbolize/gimli/elf.rs
+++ b/src/symbolize/gimli/elf.rs
@@ -5,8 +5,9 @@ use super::mystd::fs;
 use super::mystd::os::unix::ffi::{OsStrExt, OsStringExt};
 use super::mystd::path::{Path, PathBuf};
 use super::Either;
-use super::{gimli, Context, Endian, EndianSlice, Mapping, Stash, Vec};
+use super::{gimli, Context, Endian, EndianSlice, Mapping, Stash};
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 use core::convert::{TryFrom, TryInto};
 use core::str;
 use object::elf::{

--- a/src/symbolize/gimli/libs_aix.rs
+++ b/src/symbolize/gimli/libs_aix.rs
@@ -1,11 +1,13 @@
-use super::mystd::borrow::ToOwned;
 use super::mystd::env;
-use super::mystd::ffi::{CStr, OsStr};
+use super::mystd::ffi::OsStr;
 use super::mystd::io::Error;
 use super::mystd::os::unix::prelude::*;
 use super::xcoff;
-use super::{Library, LibrarySegment, Vec};
+use super::{Library, LibrarySegment};
+use alloc::borrow::ToOwned;
 use alloc::vec;
+use alloc::vec::Vec;
+use core::ffi::CStr;
 use core::mem;
 
 const EXE_IMAGE_BASE: u64 = 0x100000000;

--- a/src/symbolize/gimli/libs_dl_iterate_phdr.rs
+++ b/src/symbolize/gimli/libs_dl_iterate_phdr.rs
@@ -2,11 +2,13 @@
 // and typically implement an API called `dl_iterate_phdr` to load
 // native libraries.
 
-use super::mystd::borrow::ToOwned;
 use super::mystd::env;
-use super::mystd::ffi::{CStr, OsStr};
+use super::mystd::ffi::{OsStr, OsString};
 use super::mystd::os::unix::prelude::*;
-use super::{parse_running_mmaps, Library, LibrarySegment, OsString, Vec};
+use super::{parse_running_mmaps, Library, LibrarySegment};
+use alloc::borrow::ToOwned;
+use alloc::vec::Vec;
+use core::ffi::CStr;
 use core::slice;
 
 struct CallbackData {

--- a/src/symbolize/gimli/libs_haiku.rs
+++ b/src/symbolize/gimli/libs_haiku.rs
@@ -5,11 +5,13 @@
 // that section. All the read-only segments of the ELF-binary are in
 // that part of the address space.
 
-use super::mystd::borrow::ToOwned;
-use super::mystd::ffi::{CStr, OsStr};
-use super::mystd::mem::MaybeUninit;
+use super::mystd::ffi::OsStr;
 use super::mystd::os::unix::prelude::*;
-use super::{Library, LibrarySegment, Vec};
+use super::{Library, LibrarySegment};
+use alloc::borrow::ToOwned;
+use alloc::vec::Vec;
+use core::ffi::CStr;
+use core::mem::MaybeUninit;
 
 pub(super) fn native_libraries() -> Vec<Library> {
     let mut libraries: Vec<Library> = Vec::new();

--- a/src/symbolize/gimli/libs_illumos.rs
+++ b/src/symbolize/gimli/libs_illumos.rs
@@ -1,7 +1,9 @@
-use super::mystd::borrow::ToOwned;
-use super::mystd::ffi::{CStr, OsStr};
+use super::mystd::ffi::OsStr;
 use super::mystd::os::unix::prelude::*;
-use super::{Library, LibrarySegment, Vec};
+use super::{Library, LibrarySegment};
+use alloc::borrow::ToOwned;
+use alloc::vec::Vec;
+use core::ffi::CStr;
 use core::mem;
 use object::NativeEndian;
 

--- a/src/symbolize/gimli/libs_libnx.rs
+++ b/src/symbolize/gimli/libs_libnx.rs
@@ -1,4 +1,5 @@
-use super::{Library, LibrarySegment, Vec};
+use super::{Library, LibrarySegment};
+use alloc::vec::Vec;
 
 // DevkitA64 doesn't natively support debug info, but the build system will
 // place debug info at the path `romfs:/debug_info.elf`.

--- a/src/symbolize/gimli/libs_macos.rs
+++ b/src/symbolize/gimli/libs_macos.rs
@@ -1,10 +1,11 @@
 #![allow(deprecated)]
 
-use super::mystd::ffi::{CStr, OsStr};
+use super::mystd::ffi::OsStr;
 use super::mystd::os::unix::prelude::*;
 use super::mystd::prelude::v1::*;
 use super::{Library, LibrarySegment};
 use core::convert::TryInto;
+use core::ffi::CStr;
 use core::mem;
 
 // FIXME: replace with ptr::from_ref once MSRV is high enough

--- a/src/symbolize/gimli/libs_windows.rs
+++ b/src/symbolize/gimli/libs_windows.rs
@@ -1,6 +1,7 @@
 use super::super::super::windows_sys::*;
+use super::mystd::ffi::OsString;
 use super::mystd::os::windows::prelude::*;
-use super::{coff, mmap, Library, LibrarySegment, OsString};
+use super::{coff, mmap, Library, LibrarySegment};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::mem;

--- a/src/symbolize/gimli/macho.rs
+++ b/src/symbolize/gimli/macho.rs
@@ -1,4 +1,4 @@
-use super::mystd::fs::Path;
+use super::mystd::path::Path;
 use super::{gimli, Context, Endian, EndianSlice, Mapping, Stash};
 use alloc::boxed::Box;
 use alloc::sync::Arc;

--- a/src/symbolize/gimli/macho.rs
+++ b/src/symbolize/gimli/macho.rs
@@ -1,5 +1,8 @@
-use super::{gimli, Box, Context, Endian, EndianSlice, Mapping, Path, Stash, Vec};
+use super::mystd::fs::Path;
+use super::{gimli, Context, Endian, EndianSlice, Mapping, Stash};
+use alloc::boxed::Box;
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 use core::convert::TryInto;
 use object::macho;
 use object::read::macho::{MachHeader, Nlist, Section, Segment as _};

--- a/src/symbolize/gimli/parse_running_mmaps_unix.rs
+++ b/src/symbolize/gimli/parse_running_mmaps_unix.rs
@@ -2,10 +2,12 @@
 // in `mod libs_dl_iterate_phdr` (e.g. linux, freebsd, ...); it may be more
 // general purpose, but it hasn't been tested elsewhere.
 
+use super::mystd::ffi::OsString;
 use super::mystd::fs::File;
 use super::mystd::io::Read;
-use super::mystd::str::FromStr;
-use super::{OsString, String, Vec};
+use alloc::str::String;
+use alloc::vec::Vec;
+use core::str::FromStr;
 
 #[derive(PartialEq, Eq, Debug)]
 pub(super) struct MapsEntry {

--- a/src/symbolize/gimli/parse_running_mmaps_unix.rs
+++ b/src/symbolize/gimli/parse_running_mmaps_unix.rs
@@ -5,7 +5,7 @@
 use super::mystd::ffi::OsString;
 use super::mystd::fs::File;
 use super::mystd::io::Read;
-use alloc::str::String;
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::str::FromStr;
 

--- a/src/symbolize/gimli/xcoff.rs
+++ b/src/symbolize/gimli/xcoff.rs
@@ -1,9 +1,11 @@
 use super::mystd::ffi::{OsStr, OsString};
+use super::mystd::fs::Path;
 use super::mystd::os::unix::ffi::OsStrExt;
-use super::mystd::str;
-use super::{gimli, Context, Endian, EndianSlice, Mapping, Path, Stash, Vec};
+use super::{gimli, Context, Endian, EndianSlice, Mapping, Stash};
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 use core::ops::Deref;
+use core::str;
 use object::read::archive::ArchiveFile;
 use object::read::xcoff::{FileHeader, SectionHeader, XcoffFile, XcoffSymbol};
 use object::Object as _;

--- a/src/symbolize/gimli/xcoff.rs
+++ b/src/symbolize/gimli/xcoff.rs
@@ -1,6 +1,6 @@
 use super::mystd::ffi::{OsStr, OsString};
-use super::mystd::fs::Path;
 use super::mystd::os::unix::ffi::OsStrExt;
+use super::mystd::path::Path;
 use super::{gimli, Context, Endian, EndianSlice, Mapping, Stash};
 use alloc::sync::Arc;
 use alloc::vec::Vec;


### PR DESCRIPTION
Noticed while considering `backtrace_in_libstd`. Figured it was worth making it more clear which imports *needed* std, and removing some pointless casting and such.