### PR TITLE
Update other GitHub actions

### DIFF
--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -126,7 +126,7 @@ jobs:
               { flag: "wx" },
             );
       - name: Upload size data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.1.7
         with:
           name: size-files
           path: ${{ env.SIZE_DATA_DIR }}/${{ env.SIZE_DATA_FILE }}

--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -45,11 +45,11 @@ jobs:
       # patched in to std. It's cloned here to access the Github action for
       # building and measuring the test binary.
       - name: Clone backtrace to access Github action
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ env.BACKTRACE_DIR }}
       - name: Clone Rustc
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: rust-lang/rust
           path: ${{ env.RUSTC_DIR }}
@@ -140,7 +140,7 @@ jobs:
       pull-requests: write
     steps:
       # Clone backtrace to access Github composite actions to report size.
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download size data
         uses: actions/download-artifact@v4.1.7
         with:

--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           # Bootstrap config
           cat <<EOF > config.toml
+          change-id = 9999999
           [llvm]
           download-ci-llvm = true
           [rust]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
           - os: windows-latest
             rust: nightly-x86_64-gnu
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Rust (rustup)
@@ -133,7 +133,7 @@ jobs:
     name: Windows AArch64
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Rust
@@ -155,7 +155,7 @@ jobs:
           - target: x86_64-apple-ios
             sdk: iphonesimulator
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - run: rustup target add ${{ matrix.target }}
@@ -189,7 +189,7 @@ jobs:
           - i686-linux-android
           - x86_64-linux-android
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Rust
@@ -204,7 +204,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Rust
@@ -223,7 +223,7 @@ jobs:
           - x86_64-fortanix-unknown-sgx
           - x86_64-unknown-illumos
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Rust
@@ -244,7 +244,7 @@ jobs:
           - os: ubuntu-20.04
           - os: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Rust
@@ -255,7 +255,7 @@ jobs:
     name: Miri
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Miri


### PR DESCRIPTION
We started using download-artifact@v4.1.7 in https://github.com/rust-lang/backtrace-rs/pull/663 but the rest weren't so security critical so dependabot didn't bump them. Not having them "just" breaks a workflow or two. So bump them.