### PR TITLE
Use fuzzy version for `{up,down}load-artifact`

### DIFF
--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -127,7 +127,7 @@ jobs:
               { flag: "wx" },
             );
       - name: Upload size data
-        uses: actions/upload-artifact@v4.1.7
+        uses: actions/upload-artifact@v4
         with:
           name: size-files
           path: ${{ env.SIZE_DATA_DIR }}/${{ env.SIZE_DATA_FILE }}
@@ -143,7 +143,7 @@ jobs:
       # Clone backtrace to access Github composite actions to report size.
       - uses: actions/checkout@v4
       - name: Download size data
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name: size-files
           path: ${{ env.SIZE_DATA_DIR }}


### PR DESCRIPTION
I made a mistake in assuming there would be a twin for every version of the upload/download artifact changes. There are very not. Alternatively, we can use v4.1.8 for download-artifact and v4.4.0 for upload-artifact.