### PR TITLE
Fix CI for lints and migrations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -235,7 +235,7 @@ jobs:
       matrix:
         target:
           - wasm32-unknown-unknown
-          - wasm32-wasi
+          - wasm32-wasip1
           - x86_64-unknown-fuchsia
           - x86_64-fortanix-unknown-sgx
           - x86_64-unknown-illumos

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
         env:
           RUSTFLAGS: "-C link-arg=-Wl,--compress-debug-sections=zlib"
-      - run: cargo test
+      - run: cargo test --features "ruzstd"
         if: contains(matrix.os, 'ubuntu-24.04') ||
             (contains(matrix.os, 'ubuntu') && contains(matrix.rust, 'nightly'))
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ windows-targets = "0.52.6"
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
 miniz_oxide = { version = "0.8", default-features = false }
-ruzstd = { version = "0.7.2", default-features = false }
+ruzstd = { version = "0.7.3", default-features = false, optional = true }
 addr2line = { version = "0.24.0", default-features = false }
 libc = { version = "0.2.156", default-features = false }
 
@@ -64,6 +64,8 @@ default = ["std"]
 std = []
 
 serialize-serde = ["serde"]
+
+ruzstd = ["dep:ruzstd"]
 
 #=======================================
 # Deprecated/internal features

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -363,6 +363,8 @@ impl Cache {
         // never happen, and symbolicating backtraces would be ssssllllooooowwww.
         static mut MAPPINGS_CACHE: Option<Cache> = None;
 
+        // FIXME: https://github.com/rust-lang/backtrace-rs/issues/678
+        #[allow(static_mut_refs)]
         f(MAPPINGS_CACHE.get_or_insert_with(Cache::new))
     }
 


### PR DESCRIPTION
This doesn't fix #678 but will hopefully get CI passing again.

Longer term, I would like to change our dbghelp library loading to be less eek.