### PR TITLE
Cut backtrace 0.3.75

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 dependencies = [
  "addr2line",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Make a release that includes the Windows raw dylib workaround (#677)

Changes:

- Recognize windows-sys signatures as "C" or "system" depending on cfg (#677)
- Add support for symbolicating APK/ZIP-embedded libraries on Android (#662)
- Revise `dl_iterate_phdr` callback to be sound-ish (#660)
- MSRV is now 1.73