### PR TITLE
Test Mac Catalyst in CI, and clean up unnecessary iOS env flags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,20 +162,17 @@ jobs:
       matrix:
         include:
           - target: aarch64-apple-ios
-            sdk: iphoneos
           - target: x86_64-apple-ios
-            sdk: iphonesimulator
+          - target: aarch64-apple-ios-macabi
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
       - run: rustup target add ${{ matrix.target }}
-      - run: |
-          export RUSTFLAGS=-Dwarnings
-          export SDK_PATH=`xcrun --show-sdk-path --sdk ${{ matrix.sdk }}`
-          export RUSTFLAGS="-C link-arg=-isysroot -C link-arg=$SDK_PATH"
-          cargo test --no-run --target ${{ matrix.target }}
-        name: Build tests
+      - name: Run tests
+        run: cargo test ${{ contains(matrix.target, 'macabi') && '' || '--no-run' }} --target ${{ matrix.target }}
+        env:
+          RUSTFLAGS: -Dwarnings
 
   docker:
     name: Docker


### PR DESCRIPTION
Mac Catalyst is a technology that allows macOS to emulate or closely mimic iOS in behaviour. Let's use that in CI, as a proxy for real testing on iOS.

Also, `rustc` will figure out the SDK itself nowadays, so calling `xcrun` should be unnecessary.