### PR TITLE
Enable libunwind for rtems

### DIFF
--- a/src/backtrace/libunwind.rs
+++ b/src/backtrace/libunwind.rs
@@ -182,6 +182,7 @@ mod uw {
             not(all(target_os = "freebsd", target_arch = "arm")),
             not(all(target_os = "linux", target_arch = "arm")),
             not(all(target_os = "horizon", target_arch = "arm")),
+            not(all(target_os = "rtems", target_arch = "arm")),
             not(all(target_os = "vita", target_arch = "arm")),
         ))] {
             extern "C" {

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -174,7 +174,7 @@ cfg_if::cfg_if! {
         any(
             all(
                 unix,
-                not(any(target_os = "emscripten", target_os = "rtems")),
+                not(target_os = "emscripten"),
                 not(all(target_os = "ios", target_arch = "arm")),
             ),
             all(


### PR DESCRIPTION
In order to switch the RTEMS port to `panic_unwind` these changes need to be added in `backtrace_rs`. 

Once this is merged and the submodule updated in rustc I will add another PR there to make the switch.