### PR TITLE
remove ubuntu-20

### DIFF
--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -22,7 +22,9 @@ jobs:
     name: Check binary size
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        # FIXME(jubilee): the immutable upload needs us to disambiguate things
+        # platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
-            rust: stable
-          - os: ubuntu-20.04
-            rust: beta
-          - os: ubuntu-20.04
-            rust: nightly
           - os: ubuntu-24.04
             rust: stable
           - os: ubuntu-24.04
@@ -185,7 +179,7 @@ jobs:
 
   docker:
     name: Docker
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -219,7 +213,7 @@ jobs:
 
   rustfmt:
     name: Rustfmt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -230,7 +224,7 @@ jobs:
 
   build:
     name: Build Targets
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         target:
@@ -258,7 +252,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
           - os: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -270,7 +264,7 @@ jobs:
 
   miri:
     name: Miri
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
ubuntu-20 will be removed in April. See announcement [here](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#ubuntu-20-image-is-closing-down).