### PR TITLE
Attempt to fix ARM32 Windows

### DIFF
--- a/src/windows_sys.rs
+++ b/src/windows_sys.rs
@@ -246,64 +246,6 @@ pub struct CONTEXT {
     pub ExtendedRegisters: [u8; 512],
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(target_arch = "arm")] {
-        pub const ARM_MAX_BREAKPOINTS: usize = 8;
-        pub const ARM_MAX_WATCHPOINTS: usize = 1;
-
-        #[repr(C)]
-        #[derive(Clone, Copy)]
-        pub struct NEON128 {
-            pub Low: u64,
-            pub High: i64,
-        }
-
-        #[repr(C)]
-        #[derive(Clone, Copy)]
-        pub union CONTEXT_FloatRegs{
-            pub Q: [NEON128; 16],
-            pub D: [u64; 32],
-            pub S: [u32; 32],
-        }
-
-        #[repr(C)]
-        #[derive(Clone, Copy)]
-        pub struct CONTEXT {
-            pub ContextFlags: u32,
-            pub R0: u32,
-            pub R1: u32,
-            pub R2: u32,
-            pub R3: u32,
-            pub R4: u32,
-            pub R5: u32,
-            pub R6: u32,
-            pub R7: u32,
-            pub R8: u32,
-            pub R9: u32,
-            pub R10: u32,
-            pub R11: u32,
-            pub R12: u32,
-            // Control registers
-            pub Sp: u32,
-            pub Lr: u32,
-            pub Pc: u32,
-            pub Cpsr: u32,
-            // Floating-point registers
-            pub Fpsrc: u32,
-            pub Padding: u32,
-            pub u: CONTEXT_FloatRegs,
-            // Debug registers
-            pub Bvr: [u32; ARM_MAX_BREAKPOINTS],
-            pub Bcr: [u32; ARM_MAX_BREAKPOINTS],
-            pub Wvr: [u32; ARM_MAX_WATCHPOINTS],
-            pub Wcr: [u32; ARM_MAX_WATCHPOINTS],
-            pub Padding2: [u32; 2],
-        }
-
-        pub const IMAGE_FILE_MACHINE_ARMNT: IMAGE_FILE_MACHINE = 0x01c4;
-    }
-}
-
 pub type CONTEXT_FLAGS = u32;
 pub const CP_UTF8: u32 = 65001u32;
 pub type CREATE_TOOLHELP_SNAPSHOT_FLAGS = u32;
@@ -721,3 +663,6 @@ pub struct XSAVE_FORMAT {
     pub XmmRegisters: [M128A; 8],
     pub Reserved4: [u8; 224],
 }
+
+#[cfg(target_arch = "arm")]
+include!("./windows_sys_arm32_shim.rs");

--- a/src/windows_sys.rs
+++ b/src/windows_sys.rs
@@ -253,7 +253,18 @@ cfg_if::cfg_if! {
 
         #[repr(C)]
         #[derive(Clone, Copy)]
-        pub struct CONTEXT_u([u64; 32]);
+        pub struct NEON128 {
+            pub Low: u64,
+            pub High: i64,
+        }
+
+        #[repr(C)]
+        #[derive(Clone, Copy)]
+        pub union CONTEXT_FloatRegs{
+            pub Q: [NEON128; 16],
+            pub D: [u64; 32],
+            pub S: [u32; 32],
+        }
 
         #[repr(C)]
         #[derive(Clone, Copy)]
@@ -272,13 +283,16 @@ cfg_if::cfg_if! {
             pub R10: u32,
             pub R11: u32,
             pub R12: u32,
+            // Control registers
             pub Sp: u32,
             pub Lr: u32,
             pub Pc: u32,
             pub Cpsr: u32,
+            // Floating-point registers
             pub Fpsrc: u32,
             pub Padding: u32,
-            pub u: CONTEXT_u,
+            pub u: CONTEXT_FloatRegs,
+            // Debug registers
             pub Bvr: [u32; ARM_MAX_BREAKPOINTS],
             pub Bcr: [u32; ARM_MAX_BREAKPOINTS],
             pub Wvr: [u32; ARM_MAX_WATCHPOINTS],

--- a/src/windows_sys.rs
+++ b/src/windows_sys.rs
@@ -245,6 +245,51 @@ pub struct CONTEXT {
     pub SegSs: u32,
     pub ExtendedRegisters: [u8; 512],
 }
+
+cfg_if::cfg_if! {
+    if #[cfg(target_arch = "arm")] {
+        pub const ARM_MAX_BREAKPOINTS: usize = 8;
+        pub const ARM_MAX_WATCHPOINTS: usize = 1;
+
+        #[repr(C)]
+        #[derive(Clone, Copy)]
+        pub struct CONTEXT_u([u64; 32]);
+
+        #[repr(C)]
+        #[derive(Clone, Copy)]
+        pub struct CONTEXT {
+            pub ContextFlags: u32,
+            pub R0: u32,
+            pub R1: u32,
+            pub R2: u32,
+            pub R3: u32,
+            pub R4: u32,
+            pub R5: u32,
+            pub R6: u32,
+            pub R7: u32,
+            pub R8: u32,
+            pub R9: u32,
+            pub R10: u32,
+            pub R11: u32,
+            pub R12: u32,
+            pub Sp: u32,
+            pub Lr: u32,
+            pub Pc: u32,
+            pub Cpsr: u32,
+            pub Fpsrc: u32,
+            pub Padding: u32,
+            pub u: CONTEXT_u,
+            pub Bvr: [u32; ARM_MAX_BREAKPOINTS],
+            pub Bcr: [u32; ARM_MAX_BREAKPOINTS],
+            pub Wvr: [u32; ARM_MAX_WATCHPOINTS],
+            pub Wcr: [u32; ARM_MAX_WATCHPOINTS],
+            pub Padding2: [u32; 2],
+        }
+
+        pub const IMAGE_FILE_MACHINE_ARMNT: IMAGE_FILE_MACHINE = 0x01c4;
+    }
+}
+
 pub type CONTEXT_FLAGS = u32;
 pub const CP_UTF8: u32 = 65001u32;
 pub type CREATE_TOOLHELP_SNAPSHOT_FLAGS = u32;

--- a/src/windows_sys_arm32_shim.rs
+++ b/src/windows_sys_arm32_shim.rs
@@ -1,0 +1,53 @@
+pub const ARM_MAX_BREAKPOINTS: usize = 8;
+pub const ARM_MAX_WATCHPOINTS: usize = 1;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct NEON128 {
+    pub Low: u64,
+    pub High: i64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union CONTEXT_FloatRegs {
+    pub Q: [NEON128; 16],
+    pub D: [u64; 32],
+    pub S: [u32; 32],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct CONTEXT {
+    pub ContextFlags: u32,
+    pub R0: u32,
+    pub R1: u32,
+    pub R2: u32,
+    pub R3: u32,
+    pub R4: u32,
+    pub R5: u32,
+    pub R6: u32,
+    pub R7: u32,
+    pub R8: u32,
+    pub R9: u32,
+    pub R10: u32,
+    pub R11: u32,
+    pub R12: u32,
+    // Control registers
+    pub Sp: u32,
+    pub Lr: u32,
+    pub Pc: u32,
+    pub Cpsr: u32,
+    // Floating-point registers
+    pub Fpsrc: u32,
+    pub Padding: u32,
+    pub u: CONTEXT_FloatRegs,
+    // Debug registers
+    pub Bvr: [u32; ARM_MAX_BREAKPOINTS],
+    pub Bcr: [u32; ARM_MAX_BREAKPOINTS],
+    pub Wvr: [u32; ARM_MAX_WATCHPOINTS],
+    pub Wcr: [u32; ARM_MAX_WATCHPOINTS],
+    pub Padding2: [u32; 2],
+}
+
+pub const IMAGE_FILE_MACHINE_ARMNT: IMAGE_FILE_MACHINE = 0x01c4;


### PR DESCRIPTION
Currently `thumbv7a-pc-windows-msvc` and `thumbv7a-pc-windows-msvc` fails to build due to lack of a few symbols generated by `windows-targets`. As `backtrace` being a dependency of Rust `std`, `build-std` feature targeting these platforms also fails. The fix here is definitely not a good idea which is modifying a generated file, but it shows the possibility to have the issue solved at least to unblock `build-std` on these platforms.

This was how I verified it using `1.85.0-nightly (9e136a30a 2024-12-19)` toolchain:

```bash
cargo +nightly build -Z build-std=core,alloc,panic_abort --target thumbv7a-uwp-windows-msvc --no-default-features
cargo +nightly build -Z build-std=core,alloc,panic_abort --target thumbv7a-pc-windows-msvc --no-default-features
```
<details>
<summary>which produced the following output:</summary>

```
cargo +nightly build -Z build-std=core,alloc,panic_abort --target thumbv7a-uwp-windows-msvc --no-default-features                                         ─╯
   Compiling backtrace v0.3.74 (<path-to>\backtrace-rs)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s

cargo +nightly build -Z build-std=core,alloc,panic_abort --target thumbv7a-pc-windows-msvc --no-default-features                                          ─╯
   Compiling backtrace v0.3.74 (<path-to>\backtrace-rs)
warning: unnecessary `unsafe` block
   --> src\backtrace\dbghelp32.rs:218:5
    |
218 |     unsafe {
    |     ^^^^^^ unnecessary `unsafe` block
    |
    = note: `#[warn(unused_unsafe)]` on by default

warning: creating a mutable reference to mutable static is discouraged
   --> src\dbghelp.rs:115:21
    |
115 |                       DBGHELP.$name().unwrap()
    |                       ^^^^^^^ mutable reference to mutable static
...
128 | / dbghelp! {
129 | |     extern "system" {
130 | |         fn SymGetOptions() -> u32;
131 | |         fn SymSetOptions(options: u32) -> u32;
...   |
223 | | }
    | |_- in this macro invocation
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
    = note: `#[warn(static_mut_refs)]` on by default
    = note: this warning originates in the macro `dbghelp` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: creating a mutable reference to mutable static is discouraged
   --> src\dbghelp.rs:115:21
    |
115 |                       DBGHELP.$name().unwrap()
    |                       ^^^^^^^ mutable reference to mutable static
...
128 | / dbghelp! {
129 | |     extern "system" {
130 | |         fn SymGetOptions() -> u32;
131 | |         fn SymSetOptions(options: u32) -> u32;
...   |
223 | | }
    | |_- in this macro invocation
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
    = note: this warning originates in the macro `dbghelp` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: creating a mutable reference to mutable static is discouraged
   --> src\dbghelp.rs:321:9
    |
321 |         DBGHELP.ensure_open()?;
    |         ^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: creating a mutable reference to mutable static is discouraged
   --> src\dbghelp.rs:333:20
    |
333 |         let orig = DBGHELP.SymGetOptions()?();
    |                    ^^^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: creating a mutable reference to mutable static is discouraged
   --> src\dbghelp.rs:338:9
    |
338 |         DBGHELP.SymSetOptions()?(orig | SYMOPT_DEFERRED_LOADS);
    |         ^^^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: creating a mutable reference to mutable static is discouraged
   --> src\dbghelp.rs:352:9
    |
352 |         DBGHELP.SymInitializeW()?(GetCurrentProcess(), ptr::null_mut(), TRUE);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: creating a mutable reference to mutable static is discouraged
   --> src\dbghelp.rs:366:12
    |
366 |         if DBGHELP.SymGetSearchPathW()?(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: creating a mutable reference to mutable static is discouraged
   --> src\dbghelp.rs:386:9
    |
386 |         DBGHELP.EnumerateLoadedModulesW64()?(
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: creating a mutable reference to mutable static is discouraged
   --> src\dbghelp.rs:395:9
    |
395 |         DBGHELP.SymSetSearchPathW()?(GetCurrentProcess(), new_search_path.as_ptr());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable reference to mutable static
    |
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
    = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives

warning: `backtrace` (lib) generated 24 warnings (14 duplicates)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s
```

</details>

Any input on better ways to handle this will be appreciated! In Rust std I can see it's solved here https://github.com/rust-lang/rust/blob/8a1f8039a7ded79d3d4fe97b110016d89f2b11e2/src/tools/generate-windows-sys/src/main.rs#L8 . Not sure if we can apply something similar here.

Xref: #572 #634 