### PR TITLE
Disable libunwind for NuttX

### DIFF
--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -174,7 +174,7 @@ cfg_if::cfg_if! {
         any(
             all(
                 unix,
-                not(target_os = "emscripten"),
+                not(any(target_os = "emscripten", target_os = "nuttx")),
                 not(all(target_os = "ios", target_arch = "arm")),
             ),
             all(


### PR DESCRIPTION
NuttX is a resource-constrained system, libunwind is too large for it in terms of both code size and memory usage. So we disable libunwind for NuttX.