### PR TITLE
Parse short backtraces out of debuginfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,8 @@ version = "0.1.0"
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+version = "0.31.1"
+source = "git+https://github.com/jyn514/gimli?branch=shared-attrs#afbceac5bbc683020ba696d23501f34ee6f67ea4"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ version = "0.36.0"
 default-features = false
 features = ['read_core', 'elf', 'macho', 'pe', 'xcoff', 'unaligned', 'archive']
 
+[patch.crates-io]
+gimli = { git = "https://github.com/jyn514/gimli", branch = "shared-attrs", version = "0.31.1" }
+
 [dev-dependencies]
 dylib-dep = { path = "crates/dylib-dep" }
 libloading = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub use self::backtrace::{trace_unsynchronized, Frame};
 mod backtrace;
 
 pub use self::symbolize::resolve_frame_unsynchronized;
-pub use self::symbolize::{resolve_unsynchronized, Symbol, SymbolName};
+pub use self::symbolize::{resolve_unsynchronized, ShortBacktrace, Symbol, SymbolName};
 mod symbolize;
 
 pub use self::types::BytesOrWideString;

--- a/src/symbolize/dbghelp.rs
+++ b/src/symbolize/dbghelp.rs
@@ -73,6 +73,12 @@ impl Symbol<'_> {
 
         self._filename_cache.as_ref().map(Path::new)
     }
+
+    pub fn short_backtrace(&self) -> Option<super::ShortBacktrace> {
+        // Not supported with dllhelp API.
+        // FIXME: might be doable with [llvm.codeview.annotation](https://reviews.llvm.org/D36904)?
+        None
+    }
 }
 
 #[repr(C, align(8))]

--- a/src/symbolize/gimli/coff.rs
+++ b/src/symbolize/gimli/coff.rs
@@ -100,7 +100,7 @@ impl<'a> Object<'a> {
         self.symbols[i].1.name(self.strings).ok()
     }
 
-    pub(super) fn search_object_map(&self, _addr: u64) -> Option<(&Context<'_>, u64)> {
+    pub(super) fn search_object_map(&mut self, _addr: u64) -> Option<(&Context<'_>, u64)> {
         None
     }
 }

--- a/src/symbolize/gimli/elf.rs
+++ b/src/symbolize/gimli/elf.rs
@@ -238,7 +238,7 @@ impl<'a> Object<'a> {
         }
     }
 
-    pub(super) fn search_object_map(&self, _addr: u64) -> Option<(&Context<'_>, u64)> {
+    pub(super) fn search_object_map(&mut self, _addr: u64) -> Option<(&Context<'_>, u64)> {
         None
     }
 

--- a/src/symbolize/gimli/xcoff.rs
+++ b/src/symbolize/gimli/xcoff.rs
@@ -172,7 +172,7 @@ impl<'a> Object<'a> {
         }
     }
 
-    pub(super) fn search_object_map(&self, _addr: u64) -> Option<(&Context<'_>, u64)> {
+    pub(super) fn search_object_map(&mut self, _addr: u64) -> Option<(&Context<'_>, u64)> {
         None
     }
 }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -251,6 +251,16 @@ impl Symbol {
     pub fn filename(&self) -> Option<&Path> {
         self.inner.filename()
     }
+
+    /// Returns the short backtrace printing info for this function.
+    ///
+    /// This is currently only available when libbacktrace or gimli is being
+    /// used (e.g. unix platforms other) and when a binary is compiled with
+    /// debuginfo. If neither of these conditions is met then this will likely
+    /// return `None`.
+    pub fn short_backtrace(&self) -> Option<ShortBacktrace> {
+        self.inner.short_backtrace()
+    }
 }
 
 impl fmt::Debug for Symbol {
@@ -405,6 +415,14 @@ impl<'a> fmt::Debug for SymbolName<'a> {
 
         format_symbol_name(fmt::Debug::fmt, self.bytes, f)
     }
+}
+
+#[derive(Copy, Clone, Debug)]
+#[allow(missing_docs)]
+pub enum ShortBacktrace {
+    ThisFrameOnly,
+    Start,
+    End,
 }
 
 /// Attempt to reclaim that cached memory used to symbolicate addresses.

--- a/src/symbolize/noop.rs
+++ b/src/symbolize/noop.rs
@@ -1,7 +1,7 @@
 //! Empty symbolication strategy used to compile for platforms that have no
 //! support.
 
-use super::{BytesOrWideString, ResolveWhat, SymbolName};
+use super::{BytesOrWideString, ResolveWhat, ShortBacktrace, SymbolName};
 use core::ffi::c_void;
 use core::marker;
 
@@ -34,6 +34,10 @@ impl Symbol<'_> {
     }
 
     pub fn colno(&self) -> Option<u32> {
+        None
+    }
+
+    pub fn short_backtrace(&self) -> Option<ShortBacktrace> {
         None
     }
 }


### PR DESCRIPTION
This implements the runtime side of https://github.com/rust-lang/compiler-team/issues/818.

- Extract a helper out of `find_frames` for iterating over a `LookupContinuation`
- Make the type signature for `search_object_map` consistent across all platforms. Backtraces are inherently platform specific, but let's not make it any harder on ourselves than we have to.
- Add a new `pub fn short_backtraces() -> enum { ThisFrameOnly, Start, End }` API
- Use the new [`gimli::UnitRef::shared_attrs`](https://github.com/gimli-rs/gimli/pull/756) API to determine whether a given frame has a short backtrace. This, for now, requires a git dependency on gimli.

Note that this currently does not work on MacOS. I do not have a Mac to test this; someone lent me theirs and I tracked it down to `cx.find_dwarf_and_unit` returning `None`, but I have not had the time or resources to narrow it down further than that.