### PR TITLE
Prepare backtrace for Rust 2024

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -256,7 +256,7 @@ jobs:
         with:
           submodules: true
       - name: Install Rust
-        run: rustup update 1.79.0 --no-self-update && rustup default 1.79.0
+        run: rustup update 1.82.0 --no-self-update && rustup default 1.82.0
       - run: cargo build
 
   miri:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ autoexamples = true
 autotests = true
 edition = "2021"
 exclude = ["/ci/"]
-rust-version = "1.79.0"
+rust-version = "1.82.0"
 
 [workspace]
 members = ['crates/cpp_smoke_test', 'crates/as-if-std']

--- a/src/backtrace/libunwind.rs
+++ b/src/backtrace/libunwind.rs
@@ -170,7 +170,7 @@ mod uw {
     pub type _Unwind_Trace_Fn =
         extern "C" fn(ctx: *mut _Unwind_Context, arg: *mut c_void) -> _Unwind_Reason_Code;
 
-    extern "C" {
+    unsafe extern "C" {
         pub fn _Unwind_Backtrace(
             trace: _Unwind_Trace_Fn,
             trace_argument: *mut c_void,
@@ -188,7 +188,7 @@ mod uw {
             not(all(target_os = "vita", target_arch = "arm")),
             not(all(target_os = "nuttx", target_arch = "arm")),
         ))] {
-            extern "C" {
+            unsafe extern "C" {
                 pub fn _Unwind_GetIP(ctx: *mut _Unwind_Context) -> libc::uintptr_t;
                 pub fn _Unwind_FindEnclosingFunction(pc: *mut c_void) -> *mut c_void;
 
@@ -208,7 +208,7 @@ mod uw {
             // instead of relying on _Unwind_GetCFA.
             #[cfg(all(target_os = "linux", target_arch = "s390x"))]
             pub unsafe fn get_sp(ctx: *mut _Unwind_Context) -> libc::uintptr_t {
-                extern "C" {
+                unsafe extern "C" {
                     pub fn _Unwind_GetGR(ctx: *mut _Unwind_Context, index: libc::c_int) -> libc::uintptr_t;
                 }
                 unsafe { _Unwind_GetGR(ctx, 15) }
@@ -248,7 +248,7 @@ mod uw {
             }
 
             type _Unwind_Word = libc::c_uint;
-            extern "C" {
+            unsafe extern "C" {
                 fn _Unwind_VRS_Get(
                     ctx: *mut _Unwind_Context,
                     klass: _Unwind_VRS_RegClass,

--- a/src/backtrace/libunwind.rs
+++ b/src/backtrace/libunwind.rs
@@ -113,7 +113,9 @@ impl Drop for Bomb {
 
 #[inline(always)]
 pub unsafe fn trace(mut cb: &mut dyn FnMut(&super::Frame) -> bool) {
-    uw::_Unwind_Backtrace(trace_fn, addr_of_mut!(cb).cast());
+    unsafe {
+        uw::_Unwind_Backtrace(trace_fn, addr_of_mut!(cb).cast());
+    }
 
     extern "C" fn trace_fn(
         ctx: *mut uw::_Unwind_Context,
@@ -209,7 +211,7 @@ mod uw {
                 extern "C" {
                     pub fn _Unwind_GetGR(ctx: *mut _Unwind_Context, index: libc::c_int) -> libc::uintptr_t;
                 }
-                _Unwind_GetGR(ctx, 15)
+                unsafe { _Unwind_GetGR(ctx, 15) }
             }
         } else {
             use core::ptr::addr_of_mut;
@@ -259,13 +261,15 @@ mod uw {
             pub unsafe fn _Unwind_GetIP(ctx: *mut _Unwind_Context) -> libc::uintptr_t {
                 let mut val: _Unwind_Word = 0;
                 let ptr = addr_of_mut!(val);
-                let _ = _Unwind_VRS_Get(
-                    ctx,
-                    _Unwind_VRS_RegClass::_UVRSC_CORE,
-                    15,
-                    _Unwind_VRS_DataRepresentation::_UVRSD_UINT32,
-                    ptr.cast::<c_void>(),
-                );
+                unsafe {
+                    let _ = _Unwind_VRS_Get(
+                        ctx,
+                        _Unwind_VRS_RegClass::_UVRSC_CORE,
+                        15,
+                        _Unwind_VRS_DataRepresentation::_UVRSD_UINT32,
+                        ptr.cast::<c_void>(),
+                    );
+                }
                 (val & !1) as libc::uintptr_t
             }
 
@@ -275,13 +279,15 @@ mod uw {
             pub unsafe fn get_sp(ctx: *mut _Unwind_Context) -> libc::uintptr_t {
                 let mut val: _Unwind_Word = 0;
                 let ptr = addr_of_mut!(val);
-                let _ = _Unwind_VRS_Get(
-                    ctx,
-                    _Unwind_VRS_RegClass::_UVRSC_CORE,
-                    SP,
-                    _Unwind_VRS_DataRepresentation::_UVRSD_UINT32,
-                    ptr.cast::<c_void>(),
-                );
+                unsafe {
+                    let _ = _Unwind_VRS_Get(
+                        ctx,
+                        _Unwind_VRS_RegClass::_UVRSC_CORE,
+                        SP,
+                        _Unwind_VRS_DataRepresentation::_UVRSD_UINT32,
+                        ptr.cast::<c_void>(),
+                    );
+                }
                 val as libc::uintptr_t
             }
 

--- a/src/backtrace/miri.rs
+++ b/src/backtrace/miri.rs
@@ -2,7 +2,7 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::ffi::c_void;
 
-extern "Rust" {
+unsafe extern "Rust" {
     fn miri_backtrace_size(flags: u64) -> usize;
     fn miri_get_backtrace(flags: u64, buf: *mut *mut ());
     fn miri_resolve_frame(ptr: *mut (), flags: u64) -> MiriFrame;

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -63,7 +63,7 @@ pub fn trace<F: FnMut(&Frame) -> bool>(cb: F) {
 ///
 /// See information on `trace` for caveats on `cb` panicking.
 pub unsafe fn trace_unsynchronized<F: FnMut(&Frame) -> bool>(mut cb: F) {
-    trace_imp(&mut cb)
+    unsafe { trace_imp(&mut cb) }
 }
 
 /// A trait representing one frame of a backtrace, yielded to the `trace`

--- a/src/backtrace/noop.rs
+++ b/src/backtrace/noop.rs
@@ -4,8 +4,11 @@
 use core::ffi::c_void;
 use core::ptr::null_mut;
 
+// SAFETY: This function is safe to call. It is only marked as `unsafe` to
+// avoid having to allow `unused_unsafe` since other implementations are
+// unsafe.
 #[inline(always)]
-pub fn trace(_cb: &mut dyn FnMut(&super::Frame) -> bool) {}
+pub unsafe fn trace(_cb: &mut dyn FnMut(&super::Frame) -> bool) {}
 
 #[derive(Clone)]
 pub struct Frame;

--- a/src/backtrace/win64.rs
+++ b/src/backtrace/win64.rs
@@ -80,6 +80,7 @@ pub unsafe fn trace(cb: &mut dyn FnMut(&super::Frame) -> bool) {
     use core::ptr;
 
     // Capture the initial context to start walking from.
+    // FIXME: shouldn't this have a Default impl?
     let mut context = unsafe { core::mem::zeroed::<MyContext>() };
     unsafe { RtlCaptureContext(&mut context.0) };
 

--- a/src/backtrace/win64.rs
+++ b/src/backtrace/win64.rs
@@ -80,8 +80,8 @@ pub unsafe fn trace(cb: &mut dyn FnMut(&super::Frame) -> bool) {
     use core::ptr;
 
     // Capture the initial context to start walking from.
-    let mut context = core::mem::zeroed::<MyContext>();
-    RtlCaptureContext(&mut context.0);
+    let mut context = unsafe { core::mem::zeroed::<MyContext>() };
+    unsafe { RtlCaptureContext(&mut context.0) };
 
     loop {
         let ip = context.ip();
@@ -93,7 +93,7 @@ pub unsafe fn trace(cb: &mut dyn FnMut(&super::Frame) -> bool) {
         // us to backtrace through JIT frames.
         // Note that `RtlLookupFunctionEntry` only works for in-process backtraces,
         // but that's all we support anyway, so it all lines up well.
-        let fn_entry = RtlLookupFunctionEntry(ip, &mut base, ptr::null_mut());
+        let fn_entry = unsafe { RtlLookupFunctionEntry(ip, &mut base, ptr::null_mut()) };
         if fn_entry.is_null() {
             // No function entry could be found - this may indicate a corrupt
             // stack or that a binary was unloaded (amongst other issues). Stop
@@ -124,16 +124,18 @@ pub unsafe fn trace(cb: &mut dyn FnMut(&super::Frame) -> bool) {
         let previous_sp = context.sp();
         let mut handler_data = 0usize;
         let mut establisher_frame = 0;
-        RtlVirtualUnwind(
-            0,
-            base,
-            ip,
-            fn_entry,
-            &mut context.0,
-            ptr::addr_of_mut!(handler_data).cast::<*mut c_void>(),
-            &mut establisher_frame,
-            ptr::null_mut(),
-        );
+        unsafe {
+            RtlVirtualUnwind(
+                0,
+                base,
+                ip,
+                fn_entry,
+                &mut context.0,
+                ptr::addr_of_mut!(handler_data).cast::<*mut c_void>(),
+                &mut establisher_frame,
+                ptr::null_mut(),
+            );
+        }
 
         // RtlVirtualUnwind indicates the end of the stack in two different ways:
         // * On x64, it sets the instruction pointer to 0.

--- a/src/print/fuchsia.rs
+++ b/src/print/fuchsia.rs
@@ -148,7 +148,7 @@ impl<'a> NoteIter<'a> {
     // can be anything but the range must be valid for this to be safe.
     unsafe fn new(base: *const u8, size: usize) -> Self {
         NoteIter {
-            base: from_raw_parts(base, size),
+            base: unsafe { from_raw_parts(base, size) },
             error: false,
         }
     }

--- a/src/print/fuchsia.rs
+++ b/src/print/fuchsia.rs
@@ -3,7 +3,7 @@ use core::mem::{size_of, transmute};
 use core::slice::from_raw_parts;
 use libc::c_char;
 
-extern "C" {
+unsafe extern "C" {
     // dl_iterate_phdr takes a callback that will receive a dl_phdr_info pointer
     // for every DSO that has been linked into the process. dl_iterate_phdr also
     // ensures that the dynamic linker is locked from start to finish of the

--- a/src/symbolize/dbghelp.rs
+++ b/src/symbolize/dbghelp.rs
@@ -266,7 +266,13 @@ unsafe fn do_resolve(
     }
     let name = ptr::addr_of!(name_buffer[..name_len]);
 
-    let mut line = unsafe { mem::zeroed::<IMAGEHLP_LINEW64>() };
+    let mut line = IMAGEHLP_LINEW64 {
+        SizeOfStruct: 0,
+        Key: core::ptr::null_mut(),
+        LineNumber: 0,
+        FileName: core::ptr::null_mut(),
+        Address: 0,
+    };
     line.SizeOfStruct = mem::size_of::<IMAGEHLP_LINEW64>() as u32;
 
     let mut filename = None;

--- a/src/symbolize/dbghelp.rs
+++ b/src/symbolize/dbghelp.rs
@@ -85,12 +85,16 @@ pub unsafe fn resolve(what: ResolveWhat<'_>, cb: &mut dyn FnMut(&super::Symbol))
         Ok(dbghelp) => dbghelp,
         Err(()) => return, // oh well...
     };
-    match what {
-        ResolveWhat::Address(_) => resolve_with_inline(&dbghelp, what.address_or_ip(), None, cb),
-        ResolveWhat::Frame(frame) => {
-            resolve_with_inline(&dbghelp, frame.ip(), frame.inner.inline_context(), cb)
-        }
-    };
+    unsafe {
+        match what {
+            ResolveWhat::Address(_) => {
+                resolve_with_inline(&dbghelp, what.address_or_ip(), None, cb)
+            }
+            ResolveWhat::Frame(frame) => {
+                resolve_with_inline(&dbghelp, frame.ip(), frame.inner.inline_context(), cb)
+            }
+        };
+    }
 }
 
 #[cfg(target_vendor = "win7")]
@@ -101,21 +105,23 @@ pub unsafe fn resolve(what: ResolveWhat<'_>, cb: &mut dyn FnMut(&super::Symbol))
         Err(()) => return, // oh well...
     };
 
-    let resolve_inner = if (*dbghelp.dbghelp()).SymAddrIncludeInlineTrace().is_some() {
-        // We are on a version of dbghelp 6.2+, which contains the more modern
-        // Inline APIs.
-        resolve_with_inline
-    } else {
-        // We are on an older version of dbghelp which doesn't contain the Inline
-        // APIs.
-        resolve_legacy
-    };
-    match what {
-        ResolveWhat::Address(_) => resolve_inner(&dbghelp, what.address_or_ip(), None, cb),
-        ResolveWhat::Frame(frame) => {
-            resolve_inner(&dbghelp, frame.ip(), frame.inner.inline_context(), cb)
-        }
-    };
+    unsafe {
+        let resolve_inner = if (*dbghelp.dbghelp()).SymAddrIncludeInlineTrace().is_some() {
+            // We are on a version of dbghelp 6.2+, which contains the more modern
+            // Inline APIs.
+            resolve_with_inline
+        } else {
+            // We are on an older version of dbghelp which doesn't contain the Inline
+            // APIs.
+            resolve_legacy
+        };
+        match what {
+            ResolveWhat::Address(_) => resolve_inner(&dbghelp, what.address_or_ip(), None, cb),
+            ResolveWhat::Frame(frame) => {
+                resolve_inner(&dbghelp, frame.ip(), frame.inner.inline_context(), cb)
+            }
+        };
+    }
 }
 
 /// Resolve the address using the legacy dbghelp API.
@@ -130,11 +136,13 @@ unsafe fn resolve_legacy(
     cb: &mut dyn FnMut(&super::Symbol),
 ) -> Option<()> {
     let addr = super::adjust_ip(addr) as u64;
-    do_resolve(
-        |info| dbghelp.SymFromAddrW()(GetCurrentProcess(), addr, &mut 0, info),
-        |line| dbghelp.SymGetLineFromAddrW64()(GetCurrentProcess(), addr, &mut 0, line),
-        cb,
-    );
+    unsafe {
+        do_resolve(
+            |info| dbghelp.SymFromAddrW()(GetCurrentProcess(), addr, &mut 0, info),
+            |line| dbghelp.SymGetLineFromAddrW64()(GetCurrentProcess(), addr, &mut 0, line),
+            cb,
+        );
+    }
     Some(())
 }
 
@@ -148,54 +156,63 @@ unsafe fn resolve_with_inline(
     inline_context: Option<u32>,
     cb: &mut dyn FnMut(&super::Symbol),
 ) -> Option<()> {
-    let current_process = GetCurrentProcess();
-    // Ensure we have the functions we need. Return if any aren't found.
-    let SymFromInlineContextW = (*dbghelp.dbghelp()).SymFromInlineContextW()?;
-    let SymGetLineFromInlineContextW = (*dbghelp.dbghelp()).SymGetLineFromInlineContextW()?;
+    unsafe {
+        let current_process = GetCurrentProcess();
+        // Ensure we have the functions we need. Return if any aren't found.
+        let SymFromInlineContextW = (*dbghelp.dbghelp()).SymFromInlineContextW()?;
+        let SymGetLineFromInlineContextW = (*dbghelp.dbghelp()).SymGetLineFromInlineContextW()?;
 
-    let addr = super::adjust_ip(addr) as u64;
+        let addr = super::adjust_ip(addr) as u64;
 
-    let (inlined_frame_count, inline_context) = if let Some(ic) = inline_context {
-        (0, ic)
-    } else {
-        let SymAddrIncludeInlineTrace = (*dbghelp.dbghelp()).SymAddrIncludeInlineTrace()?;
-        let SymQueryInlineTrace = (*dbghelp.dbghelp()).SymQueryInlineTrace()?;
+        let (inlined_frame_count, inline_context) = if let Some(ic) = inline_context {
+            (0, ic)
+        } else {
+            let SymAddrIncludeInlineTrace = (*dbghelp.dbghelp()).SymAddrIncludeInlineTrace()?;
+            let SymQueryInlineTrace = (*dbghelp.dbghelp()).SymQueryInlineTrace()?;
 
-        let mut inlined_frame_count = SymAddrIncludeInlineTrace(current_process, addr);
+            let mut inlined_frame_count = SymAddrIncludeInlineTrace(current_process, addr);
 
-        let mut inline_context = 0;
+            let mut inline_context = 0;
 
-        // If there is are inlined frames but we can't load them for some reason OR if there are no
-        // inlined frames, then we disregard inlined_frame_count and inline_context.
-        if (inlined_frame_count > 0
-            && SymQueryInlineTrace(
-                current_process,
-                addr,
-                0,
-                addr,
-                addr,
-                &mut inline_context,
-                &mut 0,
-            ) != TRUE)
-            || inlined_frame_count == 0
-        {
-            inlined_frame_count = 0;
-            inline_context = 0;
+            // If there is are inlined frames but we can't load them for some reason OR if there are no
+            // inlined frames, then we disregard inlined_frame_count and inline_context.
+            if (inlined_frame_count > 0
+                && SymQueryInlineTrace(
+                    current_process,
+                    addr,
+                    0,
+                    addr,
+                    addr,
+                    &mut inline_context,
+                    &mut 0,
+                ) != TRUE)
+                || inlined_frame_count == 0
+            {
+                inlined_frame_count = 0;
+                inline_context = 0;
+            }
+
+            (inlined_frame_count, inline_context)
+        };
+
+        let last_inline_context = inline_context + 1 + inlined_frame_count;
+
+        for inline_context in inline_context..last_inline_context {
+            do_resolve(
+                |info| SymFromInlineContextW(current_process, addr, inline_context, &mut 0, info),
+                |line| {
+                    SymGetLineFromInlineContextW(
+                        current_process,
+                        addr,
+                        inline_context,
+                        0,
+                        &mut 0,
+                        line,
+                    )
+                },
+                cb,
+            );
         }
-
-        (inlined_frame_count, inline_context)
-    };
-
-    let last_inline_context = inline_context + 1 + inlined_frame_count;
-
-    for inline_context in inline_context..last_inline_context {
-        do_resolve(
-            |info| SymFromInlineContextW(current_process, addr, inline_context, &mut 0, info),
-            |line| {
-                SymGetLineFromInlineContextW(current_process, addr, inline_context, 0, &mut 0, line)
-            },
-            cb,
-        );
     }
     Some(())
 }
@@ -207,7 +224,7 @@ unsafe fn do_resolve(
 ) {
     const SIZE: usize = 2 * MAX_SYM_NAME as usize + mem::size_of::<SYMBOL_INFOW>();
     let mut data = Aligned8([0u8; SIZE]);
-    let info = &mut *data.0.as_mut_ptr().cast::<SYMBOL_INFOW>();
+    let info = unsafe { &mut *data.0.as_mut_ptr().cast::<SYMBOL_INFOW>() };
     info.MaxNameLen = MAX_SYM_NAME as u32;
     // the struct size in C.  the value is different to
     // `size_of::<SYMBOL_INFOW>() - MAX_SYM_NAME + 1` (== 81)
@@ -227,16 +244,18 @@ unsafe fn do_resolve(
     // Reencode the utf-16 symbol to utf-8 so we can use `SymbolName::new` like
     // all other platforms
     let mut name_buffer = [0_u8; 256];
-    let mut name_len = WideCharToMultiByte(
-        CP_UTF8,
-        0,
-        name_ptr,
-        name_len as i32,
-        name_buffer.as_mut_ptr(),
-        name_buffer.len() as i32,
-        core::ptr::null_mut(),
-        core::ptr::null_mut(),
-    ) as usize;
+    let mut name_len = unsafe {
+        WideCharToMultiByte(
+            CP_UTF8,
+            0,
+            name_ptr,
+            name_len as i32,
+            name_buffer.as_mut_ptr(),
+            name_buffer.len() as i32,
+            core::ptr::null_mut(),
+            core::ptr::null_mut(),
+        ) as usize
+    };
     if name_len == 0 {
         // If the returned length is zero that means the buffer wasn't big enough.
         // However, the buffer will be filled with as much as will fit.
@@ -247,7 +266,7 @@ unsafe fn do_resolve(
     }
     let name = ptr::addr_of!(name_buffer[..name_len]);
 
-    let mut line = mem::zeroed::<IMAGEHLP_LINEW64>();
+    let mut line = unsafe { mem::zeroed::<IMAGEHLP_LINEW64>() };
     line.SizeOfStruct = mem::size_of::<IMAGEHLP_LINEW64>() as u32;
 
     let mut filename = None;
@@ -257,13 +276,15 @@ unsafe fn do_resolve(
 
         let base = line.FileName;
         let mut len = 0;
-        while *base.offset(len) != 0 {
+        while unsafe { *base.offset(len) != 0 } {
             len += 1;
         }
 
         let len = len as usize;
 
-        filename = Some(ptr_from_ref(slice::from_raw_parts(base, len)));
+        unsafe {
+            filename = Some(ptr_from_ref(slice::from_raw_parts(base, len)));
+        }
     }
 
     cb(&super::Symbol {
@@ -272,7 +293,7 @@ unsafe fn do_resolve(
             addr: info.Address as *mut _,
             line: lineno,
             filename,
-            _filename_cache: cache(filename),
+            _filename_cache: unsafe { cache(filename) },
             _marker: marker::PhantomData,
         },
     })
@@ -281,7 +302,7 @@ unsafe fn do_resolve(
 #[cfg(feature = "std")]
 unsafe fn cache(filename: Option<*const [u16]>) -> Option<::std::ffi::OsString> {
     use std::os::windows::ffi::OsStringExt;
-    filename.map(|f| ::std::ffi::OsString::from_wide(&*f))
+    unsafe { filename.map(|f| ::std::ffi::OsString::from_wide(&*f)) }
 }
 
 #[cfg(not(feature = "std"))]

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -439,6 +439,7 @@ pub unsafe fn resolve(what: ResolveWhat<'_>, cb: &mut dyn FnMut(&super::Symbol))
         // Extend the lifetime of `sym` to `'static` since we are unfortunately
         // required to here, but it's only ever going out as a reference so no
         // reference to it should be persisted beyond this frame anyway.
+        // SAFETY: praying the above is correct
         let sym = unsafe { mem::transmute::<Symbol<'_>, Symbol<'static>>(sym) };
         (cb)(&super::Symbol { inner: sym });
     };

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -341,7 +341,9 @@ fn extract_zip_path_android(path: &mystd::ffi::OsStr) -> Option<&mystd::ffi::OsS
 
 // unsafe because this is required to be externally synchronized
 pub unsafe fn clear_symbol_cache() {
-    Cache::with_global(|cache| cache.mappings.clear());
+    unsafe {
+        Cache::with_global(|cache| cache.mappings.clear());
+    }
 }
 
 impl Cache {
@@ -366,9 +368,11 @@ impl Cache {
         // never happen, and symbolicating backtraces would be ssssllllooooowwww.
         static mut MAPPINGS_CACHE: Option<Cache> = None;
 
-        // FIXME: https://github.com/rust-lang/backtrace-rs/issues/678
-        #[allow(static_mut_refs)]
-        f(MAPPINGS_CACHE.get_or_insert_with(Cache::new))
+        unsafe {
+            // FIXME: https://github.com/rust-lang/backtrace-rs/issues/678
+            #[allow(static_mut_refs)]
+            f(MAPPINGS_CACHE.get_or_insert_with(Cache::new))
+        }
     }
 
     fn avma_to_svma(&self, addr: *const u8) -> Option<(usize, *const u8)> {
@@ -435,57 +439,59 @@ pub unsafe fn resolve(what: ResolveWhat<'_>, cb: &mut dyn FnMut(&super::Symbol))
         // Extend the lifetime of `sym` to `'static` since we are unfortunately
         // required to here, but it's only ever going out as a reference so no
         // reference to it should be persisted beyond this frame anyway.
-        let sym = mem::transmute::<Symbol<'_>, Symbol<'static>>(sym);
+        let sym = unsafe { mem::transmute::<Symbol<'_>, Symbol<'static>>(sym) };
         (cb)(&super::Symbol { inner: sym });
     };
 
-    Cache::with_global(|cache| {
-        let (lib, addr) = match cache.avma_to_svma(addr.cast_const().cast::<u8>()) {
-            Some(pair) => pair,
-            None => return,
-        };
+    unsafe {
+        Cache::with_global(|cache| {
+            let (lib, addr) = match cache.avma_to_svma(addr.cast_const().cast::<u8>()) {
+                Some(pair) => pair,
+                None => return,
+            };
 
-        // Finally, get a cached mapping or create a new mapping for this file, and
-        // evaluate the DWARF info to find the file/line/name for this address.
-        let (cx, stash) = match cache.mapping_for_lib(lib) {
-            Some((cx, stash)) => (cx, stash),
-            None => return,
-        };
-        let mut any_frames = false;
-        if let Ok(mut frames) = cx.find_frames(stash, addr as u64) {
-            while let Ok(Some(frame)) = frames.next() {
-                any_frames = true;
-                let name = match frame.function {
-                    Some(f) => Some(f.name.slice()),
-                    None => cx.object.search_symtab(addr as u64),
-                };
-                call(Symbol::Frame {
-                    addr: addr as *mut c_void,
-                    location: frame.location,
-                    name,
-                });
+            // Finally, get a cached mapping or create a new mapping for this file, and
+            // evaluate the DWARF info to find the file/line/name for this address.
+            let (cx, stash) = match cache.mapping_for_lib(lib) {
+                Some((cx, stash)) => (cx, stash),
+                None => return,
+            };
+            let mut any_frames = false;
+            if let Ok(mut frames) = cx.find_frames(stash, addr as u64) {
+                while let Ok(Some(frame)) = frames.next() {
+                    any_frames = true;
+                    let name = match frame.function {
+                        Some(f) => Some(f.name.slice()),
+                        None => cx.object.search_symtab(addr as u64),
+                    };
+                    call(Symbol::Frame {
+                        addr: addr as *mut c_void,
+                        location: frame.location,
+                        name,
+                    });
+                }
             }
-        }
-        if !any_frames {
-            if let Some((object_cx, object_addr)) = cx.object.search_object_map(addr as u64) {
-                if let Ok(mut frames) = object_cx.find_frames(stash, object_addr) {
-                    while let Ok(Some(frame)) = frames.next() {
-                        any_frames = true;
-                        call(Symbol::Frame {
-                            addr: addr as *mut c_void,
-                            location: frame.location,
-                            name: frame.function.map(|f| f.name.slice()),
-                        });
+            if !any_frames {
+                if let Some((object_cx, object_addr)) = cx.object.search_object_map(addr as u64) {
+                    if let Ok(mut frames) = object_cx.find_frames(stash, object_addr) {
+                        while let Ok(Some(frame)) = frames.next() {
+                            any_frames = true;
+                            call(Symbol::Frame {
+                                addr: addr as *mut c_void,
+                                location: frame.location,
+                                name: frame.function.map(|f| f.name.slice()),
+                            });
+                        }
                     }
                 }
             }
-        }
-        if !any_frames {
-            if let Some(name) = cx.object.search_symtab(addr as u64) {
-                call(Symbol::Symtab { name });
+            if !any_frames {
+                if let Some(name) = cx.object.search_symtab(addr as u64) {
+                    call(Symbol::Symtab { name });
+                }
             }
-        }
-    });
+        });
+    }
 }
 
 pub enum Symbol<'a> {

--- a/src/symbolize/gimli/libs_aix.rs
+++ b/src/symbolize/gimli/libs_aix.rs
@@ -11,7 +11,7 @@ use core::mem;
 
 const EXE_IMAGE_BASE: u64 = 0x100000000;
 
-extern "C" {
+unsafe extern "C" {
     #[link_name = "_Errno"]
     fn errno_location() -> *mut c_int;
 }

--- a/src/symbolize/gimli/libs_illumos.rs
+++ b/src/symbolize/gimli/libs_illumos.rs
@@ -26,7 +26,7 @@ struct LinkMap {
 const RTLD_SELF: *const libc::c_void = -3isize as *const libc::c_void;
 const RTLD_DI_LINKMAP: libc::c_int = 2;
 
-extern "C" {
+unsafe extern "C" {
     fn dlinfo(
         handle: *const libc::c_void,
         request: libc::c_int,

--- a/src/symbolize/gimli/libs_libnx.rs
+++ b/src/symbolize/gimli/libs_libnx.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 // DevkitA64 doesn't natively support debug info, but the build system will
 // place debug info at the path `romfs:/debug_info.elf`.
 pub(super) fn native_libraries() -> Vec<Library> {
-    extern "C" {
+    unsafe extern "C" {
         static __start__: u8;
     }
 

--- a/src/symbolize/gimli/libs_windows.rs
+++ b/src/symbolize/gimli/libs_windows.rs
@@ -24,6 +24,7 @@ unsafe fn add_loaded_images(ret: &mut Vec<Library>) {
             return;
         }
 
+        // huge struct, probably should avoid manually initializing it even if we can
         let mut me = MaybeUninit::<MODULEENTRY32W>::zeroed().assume_init();
         me.dwSize = mem::size_of_val(&me) as u32;
         if Module32FirstW(snap, &mut me) == TRUE {

--- a/src/symbolize/gimli/mmap_unix.rs
+++ b/src/symbolize/gimli/mmap_unix.rs
@@ -16,14 +16,16 @@ pub struct Mmap {
 
 impl Mmap {
     pub unsafe fn map(file: &File, len: usize, offset: u64) -> Option<Mmap> {
-        let ptr = mmap64(
-            ptr::null_mut(),
-            len,
-            libc::PROT_READ,
-            libc::MAP_PRIVATE,
-            file.as_raw_fd(),
-            offset.try_into().ok()?,
-        );
+        let ptr = unsafe {
+            mmap64(
+                ptr::null_mut(),
+                len,
+                libc::PROT_READ,
+                libc::MAP_PRIVATE,
+                file.as_raw_fd(),
+                offset.try_into().ok()?,
+            )
+        };
         if ptr == libc::MAP_FAILED {
             return None;
         }

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -159,7 +159,7 @@ pub unsafe fn resolve_unsynchronized<F>(addr: *mut c_void, mut cb: F)
 where
     F: FnMut(&Symbol),
 {
-    imp::resolve(ResolveWhat::Address(addr), &mut cb)
+    unsafe { imp::resolve(ResolveWhat::Address(addr), &mut cb) }
 }
 
 /// Same as `resolve_frame`, only unsafe as it's unsynchronized.
@@ -175,7 +175,7 @@ pub unsafe fn resolve_frame_unsynchronized<F>(frame: &Frame, mut cb: F)
 where
     F: FnMut(&Symbol),
 {
-    imp::resolve(ResolveWhat::Frame(frame), &mut cb)
+    unsafe { imp::resolve(ResolveWhat::Frame(frame), &mut cb) }
 }
 
 /// A trait representing the resolution of a symbol in a file.


### PR DESCRIPTION
This applies some fixes so that backtrace is compatible with Rust 2024. This is needed to migrate the standard library to 2024 since it directly embeds backtrace.
