### PR TITLE
Add `optimize(size)` to some particularly large functions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,8 +137,11 @@ jobs:
 
       # Test that including as a submodule will still work, both with and without
       # the `backtrace` feature enabled.
+      # Building as if part of std requires nightly features to be available
       - run: cargo build --manifest-path crates/as-if-std/Cargo.toml
+        if: matrix.rust == 'nightly'
       - run: cargo build --manifest-path crates/as-if-std/Cargo.toml --no-default-features
+        if: matrix.rust == 'nightly'
 
   windows_arm64:
     name: Windows AArch64

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -3,4 +3,6 @@
 set -ex
 
 cargo test --target $TARGET
-cargo build --target $TARGET --manifest-path crates/as-if-std/Cargo.toml
+if rustc --version | grep nightly; then
+    cargo build --target $TARGET --manifest-path crates/as-if-std/Cargo.toml
+fi

--- a/crates/as-if-std/src/lib.rs
+++ b/crates/as-if-std/src/lib.rs
@@ -2,7 +2,7 @@
 // submodule into the standard library. We try to set this crate up similarly
 // to the standard library itself to minimize the likelihood of issues when
 // updating the `backtrace` crate.
-
+#![feature(optimize_attribute)]
 #![no_std]
 
 extern crate alloc;

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -114,6 +114,8 @@ struct Context<'a> {
 }
 
 impl<'data> Context<'data> {
+    // #[feature(optimize_attr)] is enabled when we're built inside libstd
+    #[cfg_attr(backtrace_in_libstd, optimize(size))]
     fn new(
         stash: &'data Stash,
         object: Object<'data>,
@@ -355,6 +357,8 @@ impl Cache {
     }
 
     // unsafe because this is required to be externally synchronized
+    // #[feature(optimize_attr)] is enabled when we're built inside libstd
+    #[cfg_attr(backtrace_in_libstd, optimize(size))]
     unsafe fn with_global(f: impl FnOnce(&mut Self)) {
         // A very small, very simple LRU cache for debug info mappings.
         //


### PR DESCRIPTION
When built as part of libstd, this saves a few kb in hello world binaries.

The comments are formatted like they are so that if this feature is stabilized they can be identified and used unconditionally.