### PR TITLE
Re-enable `download-ci-llvm = true` for CI

### DIFF
--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -70,6 +70,28 @@ jobs:
           incremental = false
           EOF
 
+          # Re-enable `download-ci-llvm = true` for CI
+          cat <<EOF | git apply -
+          diff --git a/src/bootstrap/src/core/config/config.rs b/src/bootstrap/src/core/config/config.rs
+          index cf4ef4ee310..fe78560fcaf 100644
+          --- a/src/bootstrap/src/core/config/config.rs
+          +++ b/src/bootstrap/src/core/config/config.rs
+          @@ -3138,13 +3138,6 @@ fn parse_download_ci_llvm(
+                               );
+                           }
+
+          -                if b && self.is_running_on_ci {
+          -                    // On CI, we must always rebuild LLVM if there were any modifications to it
+          -                    panic!(
+          -                        "\`llvm.download-ci-llvm\` cannot be set to \`true\` on CI. Use \`if-unchanged\` instead."
+          -                    );
+          -                }
+          -
+                           // If download-ci-llvm=true we also want to check that CI llvm is available
+                           b && llvm::is_ci_llvm_available_for_target(self, asserts)
+                       }
+          EOF
+
           # Test program source
           cat <<EOF > $TEST_MAIN_RS
           fn main() {


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/138704 disabled this when running in GHA, but this is not relevant for backtrace.

The patched used here is copied from `compiler/rustc_codegen_cranelift/scripts/setup_rust_fork.sh`