### PR TITLE
ci: Fix the binary size workflow

### DIFF
--- a/.github/actions/build-with-patched-std/action.yml
+++ b/.github/actions/build-with-patched-std/action.yml
@@ -31,8 +31,10 @@ runs:
         # symlink on Linux and a junction on Windows, so it will exist on both
         # platforms.
         RUSTC_BUILD_DIR: build/host
+        RUST_BACKTRACE: 1
       working-directory: ${{ inputs.rustc-dir }}
       run: |
+        set -x
         rm -rf "$RUSTC_BUILD_DIR/stage0-std"
 
         (cd library/backtrace && git checkout ${{ inputs.backtrace-commit }})

--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -13,6 +13,7 @@ on:
 # Both the "measure" and "report" jobs need to know this.
 env:
   SIZE_DATA_DIR: sizes
+  RUST_BACKTRACE: 1
 
 # Responsibility is divided between two jobs "measure" and "report", so that the
 # job that builds (and potentnially runs) untrusted code does not have PR write
@@ -55,17 +56,20 @@ jobs:
         with:
           repository: rust-lang/rust
           path: ${{ env.RUSTC_DIR }}
+          # Arbitrary version from 2024-04-28
+          ref: cc74ed08d53fbb440b4ab70035a92d89d418d23c
       - name: Set up std repository and backtrace submodule for size test
         shell: bash
         working-directory: ${{ env.RUSTC_DIR }}
         env:
           PR_SOURCE_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
+          set -x
           # Bootstrap config
-          cat <<EOF > config.toml
+          cat <<EOF > bootstrap.toml
           change-id = 9999999
           [llvm]
-          download-ci-llvm = true
+          download-ci-llvm = "if-unchanged"
           [rust]
           incremental = false
           EOF


### PR DESCRIPTION
From the bootstrap error:

     thread 'main' panicked at src/bootstrap/src/core/config/config.rs:3283:21:
    `llvm.download-ci-llvm` cannot be set to `true` on CI. Use `if-unchanged` instead.

So do that. Additionally, pin rustc to hopefully prevent similar regressions in the future.

Some settings to increase log output were also applied.