### PR TITLE
Only run check-binary-size workflow for PRs against master

### DIFF
--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -6,9 +6,8 @@ name: Check binary size
 
 on:
   pull_request_target:
-    # HACK(jubilee): something broke the distributed LLVM libso and I don't know what.
-    branches: []
-#      - master
+    branches:
+      - master
 
 # Both the "measure" and "report" jobs need to know this.
 env:

--- a/.github/workflows/check-binary-size.yml
+++ b/.github/workflows/check-binary-size.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - master
 
+# Remove all permissions for the workflow to increase security; the individual jobs
+# below specify the exact permissions they need
+permissions: {}
+
 # Both the "measure" and "report" jobs need to know this.
 env:
   SIZE_DATA_DIR: sizes


### PR DESCRIPTION
The `check-binary-size` workflow uses the `pull_request_target` event, which is inherently dangerous, see for example this [GitHub Security Lab post](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).

This pull request tries to make some precautionary changes to improve the safety of this workflow. There are to my knowledge no issues with the workflow which are directly exploitable.

Changes:
- Only run the workflow for pull requests targeting `master`
Currently the workflow uses `branches: []` which from my testing seems to act like "run for all branches", see also recent workflow runs at https://github.com/rust-lang/backtrace-rs/actions/workflows/check-binary-size.yml.
The problem with this is that `pull_request_target` uses the workflow file from the target branch of the pull request (not the default branch). If in the future a vulnerability in the check-binary-size workflow is noticed and fixed, this reduces the likelihood that there is a stale / feature branch which still contains the vulnerable workflow and that a malicious user can create a PR against that branch to still exploit the vulnerable workflow.
- Specify `permissions: {}` at workflow level
This disables all permissions for the workflow by default, and requires the individual jobs to explicitly define the permissions they need (see also [GitHub documentation for how permissions are calculated](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#how-the-permissions-are-calculated-for-a-workflow-job)). This should prevent that in the future an additional job is added to the workflow and the author forgets to specify `permissions` for it, causing implicit 'write' (or 'read', depending on [repository settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository)) permissions to be inadvertently granted to the job.
