### PR TITLE
Upgrade `ruzstd`, `object`, and `addr2line` to the latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "9acbfca36652500c911ddb767ed433e3ed99b032b5d935be73c6923662db1d43"
 dependencies = [
  "gimli",
 ]
@@ -87,9 +87,9 @@ version = "0.1.0"
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "93563d740bc9ef04104f9ed6f86f1e3275c2cdafb95664e26584b9ca807a8ffe"
 
 [[package]]
 name = "libc"
@@ -109,24 +109,24 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "03fd943161069e1768b4b3d050890ba48730e590f57e56d4aa04e7e090e61b4a"
 dependencies = [
  "memchr",
 ]
@@ -157,9 +157,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "ruzstd"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
+checksum = "3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,12 @@ windows-targets = "0.52.6"
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
 miniz_oxide = { version = "0.8", default-features = false }
-ruzstd = { version = "0.7.3", default-features = false, optional = true }
-addr2line = { version = "0.24.0", default-features = false }
+ruzstd = { version = "0.8.1", default-features = false, optional = true }
+addr2line = { version = "0.25.0", default-features = false }
 libc = { version = "0.2.156", default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies.object]
-version = "0.36.0"
+version = "0.37.0"
 default-features = false
 features = ['read_core', 'elf', 'macho', 'pe', 'xcoff', 'unaligned', 'archive']
 

--- a/crates/as-if-std/Cargo.toml
+++ b/crates/as-if-std/Cargo.toml
@@ -18,11 +18,11 @@ libc = { version = "0.2.156", default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
 miniz_oxide = { version = "0.8", optional = true, default-features = false }
-ruzstd = { version = "0.7.2", optional = true, default-features = false }
-addr2line = { version = "0.24.0", optional = true, default-features = false }
+ruzstd = { version = "0.8.1", optional = true, default-features = false }
+addr2line = { version = "0.25.0", optional = true, default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies.object]
-version = "0.36.0"
+version = "0.37.0"
 default-features = false
 optional = true
 features = ['read_core', 'elf', 'macho', 'pe', 'xcoff', 'unaligned', 'archive']

--- a/src/symbolize/gimli/elf.rs
+++ b/src/symbolize/gimli/elf.rs
@@ -362,12 +362,11 @@ fn decompress_zlib(input: &[u8], output: &mut [u8]) -> Option<()> {
 
 #[cfg(feature = "ruzstd")]
 fn decompress_zstd(mut input: &[u8], mut output: &mut [u8]) -> Option<()> {
-    use ruzstd::frame::ReadFrameHeaderError;
-    use ruzstd::frame_decoder::FrameDecoderError;
+    use ruzstd::decoding::errors::{FrameDecoderError, ReadFrameHeaderError};
     use ruzstd::io::Read;
 
     while !input.is_empty() {
-        let mut decoder = match ruzstd::StreamingDecoder::new(&mut input) {
+        let mut decoder = match ruzstd::decoding::StreamingDecoder::new(&mut input) {
             Ok(decoder) => decoder,
             Err(FrameDecoderError::ReadFrameHeaderError(ReadFrameHeaderError::SkipFrame {
                 length,


### PR DESCRIPTION
`object` released a breaking change with adjustments to `elf::R_RISCV_GNU_*` and `pe::IMAGE_WEAK_EXTERN_*` constants, as well as a changed API for Mach-O dyld. None of these are relevant to our use.

`ruzstd` moved some API around to account for compression support, the only required update for us is to change import paths.

`addr2line` only bumped the gimli version, which includes an update that will help us drop the crates.io compiler-builtins dependency from the standard library.

Object changelog: https://github.com/gimli-rs/object/blob/master/CHANGELOG.md#0370
Ruzstd changelog: https://github.com/KillingSpark/zstd-rs/releases/tag/v0.8.0
Addr2line changelog: https://github.com/gimli-rs/addr2line/blob/master/CHANGELOG.md#0250-20250611