### PR TITLE
Remove some unsafe code; fix a soundness hole

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "rustc-demangle",
  "ruzstd",
  "windows-targets",
+ "zerocopy",
 ]
 
 [[package]]
@@ -47,6 +48,7 @@ dependencies = [
  "ruzstd",
  "serde",
  "windows-targets",
+ "zerocopy",
 ]
 
 [[package]]
@@ -267,3 +269,23 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ exclude = [
 [dependencies]
 cfg-if = "1.0"
 rustc-demangle = "0.1.24"
+zerocopy = "0.8.26"
 
 # Optionally enable the ability to serialize a `Backtrace`, controlled through
 # the `serialize-serde` feature below.

--- a/crates/as-if-std/Cargo.toml
+++ b/crates/as-if-std/Cargo.toml
@@ -15,6 +15,7 @@ bench = false
 cfg-if = "1.0"
 rustc-demangle = "0.1.21"
 libc = { version = "0.2.156", default-features = false }
+zerocopy = "0.8.26"
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
 miniz_oxide = { version = "0.8", optional = true, default-features = false }

--- a/src/symbolize/gimli/libs_illumos.rs
+++ b/src/symbolize/gimli/libs_illumos.rs
@@ -4,7 +4,6 @@ use super::{Library, LibrarySegment};
 use alloc::borrow::ToOwned;
 use alloc::vec::Vec;
 use core::ffi::CStr;
-use core::mem;
 use object::NativeEndian;
 
 #[cfg(target_pointer_width = "64")]
@@ -38,8 +37,8 @@ pub(super) fn native_libraries() -> Vec<Library> {
     let mut libs = Vec::new();
 
     // Request the current link map from the runtime linker:
+    let mut map: *const LinkMap = core::ptr::null();
     let map = unsafe {
-        let mut map: *const LinkMap = mem::zeroed();
         if dlinfo(
             RTLD_SELF,
             RTLD_DI_LINKMAP,


### PR DESCRIPTION
Replace a number of lines of unsafe code with safe equivalents, some using `zerocopy`. In one instance, fix a soundness hole (#720).

Closes #720