### PR TITLE
Fix inverted "full printing" polarity logic

### DIFF
--- a/src/capture.rs
+++ b/src/capture.rs
@@ -498,7 +498,7 @@ impl fmt::Debug for Backtrace {
         let mut print_path =
             move |fmt: &mut fmt::Formatter<'_>, path: crate::BytesOrWideString<'_>| {
                 let path = path.into_path_buf();
-                if style == PrintFmt::Full {
+                if style != PrintFmt::Full {
                     if let Ok(cwd) = &cwd {
                         if let Ok(suffix) = path.strip_prefix(cwd) {
                             return fmt::Display::fmt(&suffix.display(), fmt);


### PR DESCRIPTION
As per the comment above, we'd presumably want `{:#?}` to print full paths, and `{:?}` to try to trim down the "current dir" prefix.

As of `0.3.75`, we do the opposite ([demo](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=5acacc83fa50d36fc6625de2120d5c16)).