### PR TITLE
Significantly reduce the size of Cache::with_global

### DIFF
--- a/src/symbolize/gimli/lru.rs
+++ b/src/symbolize/gimli/lru.rs
@@ -8,8 +8,8 @@ pub(crate) struct Lru<T, const N: usize> {
     arr: [MaybeUninit<T>; N],
 }
 
-impl<T, const N: usize> Default for Lru<T, N> {
-    fn default() -> Self {
+impl<T, const N: usize> Lru<T, N> {
+    pub(crate) const fn new() -> Self {
         Lru {
             len: 0,
             arr: [const { MaybeUninit::uninit() }; N],


### PR DESCRIPTION
Previously this would copy the freshly created cache into the static. Given that Cache is fairly big and for some reason LLVM decided to unroll the memcpy despite optimize(size), this produced a lot of code. This commit however changes it to create a partially initialized Cache at compile time and only initialize a single Vec field when accessing it for the first time.

This reduces the size of libas_if_std.rlib from 205kb to 199kb.