### PR TITLE
Upgrade `cpp_demangle` to the latest version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
+checksum = "4dcc405d55da54ad965aff198909afdcc8aeefc8ac6ba26d6abd19aa8aeacb2a"
 dependencies = [
  "cfg-if",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rustc-demangle = "0.1.24"
 serde = { version = "1.0", optional = true, features = ['derive'] }
 
 # Optionally demangle C++ frames' symbols in backtraces.
-cpp_demangle = { default-features = false, version = "0.4.0", optional = true, features = [
+cpp_demangle = { default-features = false, version = "0.5.0", optional = true, features = [
   "alloc",
 ] }
 


### PR DESCRIPTION
cpp_demangle 0.5.0 drops the `Display` impl on the `Symbol` object because it can subtly violate the `Display` contract. The recommended replacement is `Symbol::demangle`.

Changelog: https://github.com/gimli-rs/cpp_demangle/blob/0.5.0/CHANGELOG.md#050