### PR TITLE
CI: Use `macos-14` image for testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,12 @@ jobs:
             rust: beta
           - os: ubuntu-24.04
             rust: nightly
-          - os: macos-latest
+          - os: macos-14
             rust: stable
-          - os: macos-latest
+          - os: macos-14
             rust: nightly
+          - os: macos-latest # macOS 15
+            rust: stable
           - os: windows-latest
             rust: stable-x86_64-msvc
           - os: windows-latest
@@ -79,7 +81,11 @@ jobs:
           CARGO_PROFILE_DEV_SPLIT_DEBUGINFO: packed
           CARGO_PROFILE_TEST_SPLIT_DEBUGINFO: packed
       - run: cargo test --manifest-path crates/without_debuginfo/Cargo.toml
-      - run: cargo test --manifest-path crates/line-tables-only/Cargo.toml
+      - if: matrix.os != 'macos-latest'
+        run: cargo test --manifest-path crates/line-tables-only/Cargo.toml
+      # FIXME: This currently fails on macOS 15.
+      - if: matrix.os == 'macos-latest'
+        run: '! cargo test --manifest-path crates/line-tables-only/Cargo.toml'
 
       # Test debuginfo compression still works
       - run: cargo test
@@ -95,18 +101,18 @@ jobs:
       # Test that, on macOS, packed/unpacked debuginfo both work
       - run: cargo clean && cargo test
         # Test that, on macOS, packed/unpacked debuginfo both work
-        if: matrix.os == 'macos-latest'
+        if: contains(matrix.os, 'macos')
         env:
           CARGO_PROFILE_DEV_SPLIT_DEBUGINFO: unpacked
           CARGO_PROFILE_TEST_SPLIT_DEBUGINFO: unpacked
       - run: cargo clean && cargo test
-        if: matrix.os == 'macos-latest'
+        if: contains(matrix.os, 'macos')
         env:
           CARGO_PROFILE_DEV_SPLIT_DEBUGINFO: packed
           CARGO_PROFILE_TEST_SPLIT_DEBUGINFO: packed
       # Test that, on macOS, binaries with no UUID work
       - run: cargo clean && cargo test
-        if: matrix.os == 'macos-latest'
+        if: contains(matrix.os, 'macos')
         env:
           RUSTFLAGS: "-C link-arg=-Wl,-no_uuid"
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/backtrace-rs/issues/730. We should probably investigate the underlying issue, but this at least unbreaks CI.

CC @workingjubilee.