### PR TITLE
cleanup: simplify scan for xcoff .text section

### DIFF
--- a/src/symbolize/gimli/xcoff.rs
+++ b/src/symbolize/gimli/xcoff.rs
@@ -64,13 +64,7 @@ pub fn parse_xcoff(data: &[u8]) -> Option<Image> {
     let header = Xcoff::parse(data, &mut offset).ok()?;
     let _ = header.aux_header(data, &mut offset).ok()?;
     let sections = header.sections(data, &mut offset).ok()?;
-    if let Some(section) = sections.iter().find(|s| {
-        if let Ok(name) = str::from_utf8(&s.s_name()[0..5]) {
-            name == ".text"
-        } else {
-            false
-        }
-    }) {
+    if let Some(section) = sections.iter().find(|s| s.s_name().get(0..5) == b".text") {
         Some(Image {
             offset: section.s_scnptr() as usize,
             base: section.s_paddr() as u64,


### PR DESCRIPTION
As s_name is an 8-byte array, and we check only for ASCII characters, checking for UTF-8 validity is pure overhead.

Small cleanup opportunity I noticed while poking through the code looking for old-fashioned if-let-nesting to dedent with let-chains.