### PR TITLE
Swap `WaitForSingleObjectEx` with `WaitForSingleObject` and check result

### DIFF
--- a/bindings.txt
+++ b/bindings.txt
@@ -60,4 +60,4 @@ Windows.Win32.System.Threading.GetCurrentProcessId
 Windows.Win32.System.Threading.GetCurrentThread
 Windows.Win32.System.Threading.INFINITE
 Windows.Win32.System.Threading.ReleaseMutex
-Windows.Win32.System.Threading.WaitForSingleObjectEx
+Windows.Win32.System.Threading.WaitForSingleObject

--- a/src/dbghelp.rs
+++ b/src/dbghelp.rs
@@ -291,8 +291,9 @@ pub fn init() -> Result<Init, ()> {
             }
         }
         debug_assert!(!lock.is_null());
-        let r = WaitForSingleObjectEx(lock, INFINITE, FALSE);
-        debug_assert_eq!(r, 0);
+        if WaitForSingleObject(lock, INFINITE) != 0 {
+            return Err(());
+        }
         let ret = Init { lock };
 
         // Ok, phew! Now that we're all safely synchronized, let's actually

--- a/src/windows_sys.rs
+++ b/src/windows_sys.rs
@@ -46,7 +46,7 @@ windows_link::link!("kernel32.dll" "system" fn RtlVirtualUnwind(handlertype : RT
 #[cfg(any(target_arch = "arm64ec", target_arch = "x86_64"))]
 windows_link::link!("kernel32.dll" "system" fn RtlVirtualUnwind(handlertype : RTL_VIRTUAL_UNWIND_HANDLER_TYPE, imagebase : u64, controlpc : u64, functionentry : *const IMAGE_RUNTIME_FUNCTION_ENTRY, contextrecord : *mut CONTEXT, handlerdata : *mut *mut core::ffi::c_void, establisherframe : *mut u64, contextpointers : *mut KNONVOLATILE_CONTEXT_POINTERS) -> EXCEPTION_ROUTINE);
 windows_link::link!("kernel32.dll" "system" fn UnmapViewOfFile(lpbaseaddress : MEMORY_MAPPED_VIEW_ADDRESS) -> BOOL);
-windows_link::link!("kernel32.dll" "system" fn WaitForSingleObjectEx(hhandle : HANDLE, dwmilliseconds : u32, balertable : BOOL) -> WAIT_EVENT);
+windows_link::link!("kernel32.dll" "system" fn WaitForSingleObject(hhandle : HANDLE, dwmilliseconds : u32) -> WAIT_EVENT);
 windows_link::link!("kernel32.dll" "system" fn WideCharToMultiByte(codepage : u32, dwflags : u32, lpwidecharstr : PCWSTR, cchwidechar : i32, lpmultibytestr : PSTR, cbmultibyte : i32, lpdefaultchar : PCSTR, lpuseddefaultchar : *mut BOOL) -> i32);
 windows_link::link!("kernel32.dll" "system" fn lstrlenW(lpstring : PCWSTR) -> i32);
 #[repr(C)]


### PR DESCRIPTION
This swaps `WaitForSingleObjectEx` with the simpler `WaitForSingleObject` and also checks the result for failure.

Fixes https://github.com/rust-lang/backtrace-rs/issues/749