### PR TITLE
Add support for `aarch64-unknown-linux-pauthtest`

### DIFF
--- a/src/backtrace/libunwind.rs
+++ b/src/backtrace/libunwind.rs
@@ -79,6 +79,15 @@ impl Frame {
         // clause, and if this is fixed that test in theory can be run on macOS!
         if cfg!(target_vendor = "apple") {
             self.ip()
+        } else if cfg!(target_abi = "pauthtest") {
+            // NOTE: `_Unwind_FindEnclosingFunction` creates a fresh unwind
+            // cursor and, on the pointer-authentication-enabled AArch64
+            // reference ABI, authenticates/re-signs the supplied IP using that
+            // cursor's SP. The original frame's SP is not available through
+            // this API, so the current libunwind implementation cannot be used
+            // here: it would attempt to authenticate the IP using the wrong SP.
+            // Return the raw instruction pointer instead.
+            self.ip()
         } else {
             unsafe { uw::_Unwind_FindEnclosingFunction(self.ip()) }
         }

--- a/tests/skip_inner_frames.rs
+++ b/tests/skip_inner_frames.rs
@@ -10,6 +10,12 @@ const ENABLED: bool = cfg!(all(
     target_os = "linux",
     // On ARM finding the enclosing function is simply returning the ip itself.
     not(target_arch = "arm"),
+    // On `aarch64-unknown-linux-pauthtest` `_Unwind_FindEnclosingFunction`
+    // cannot be used safely, because instruction pointers are not in a form
+    // suitable for authentication/resigning, so `symbol_address()` returns the
+    // raw IP instead. In this case the returned address may be inside the
+    // function body rather than at its entry.
+    not(target_env = "pauthtest"),
 ));
 
 #[test]

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -25,6 +25,13 @@ fn get_actual_fn_pointer(fp: *mut c_void) -> *mut c_void {
 }
 
 #[test]
+// This test relies on recovering precise symbol addresses from instruction
+// pointers. On `aarch64-unknown-linux-pauthtest`, we cannot safely use
+// `_Unwind_FindEnclosingFunction`, and instead fall back to using raw
+// instruction pointers. As a result, symbol resolution cannot reliably
+// recover a canonical function entry address, and `sym.addr()` will often be
+// `None`. Therefore this test is disabled.
+#[cfg_attr(target_env = "pauthtest", ignore)]
 // FIXME: shouldn't ignore this test on i686-msvc, unsure why it's failing
 #[cfg_attr(all(target_arch = "x86", target_env = "msvc"), ignore)]
 #[inline(never)]
@@ -310,7 +317,10 @@ fn sp_smoke_test() {
                 let r = refs.pop().unwrap();
                 eprintln!("ref = {:p}", r);
                 if sp as usize != 0 {
-                    assert!(r > sp);
+                    // Stack grows down, however stack slots can be reused and
+                    // frame pointers ommited, `r == sp` should be a valid edge
+                    // case.
+                    assert!(r >= sp);
                     if let Some(child_ref) = child_ref {
                         assert!(sp >= child_ref);
                     }


### PR DESCRIPTION
This PR adds support for aarch64-unknown-linux-pauthtest, a target that enables Pointer Authentication Code (PAC) support in Rust on AArch64 ELF based Linux systems. It uses the aarch64-unknown-linux-pauthtest LLVM target and a pointer-authentication-enabled sysroot with a custom [musl](https://github.com/access-softek/musl) as a reference libc implementation. Dynamic linking is required, with a dynamic linker acting as the ELF interpreter that can resolve pauth relocations and enforce pointer authentication constraints.

Please consult a rust-lang PR for the details on the target: https://github.com/rust-lang/rust/pull/155722