### PR TITLE
Set no-op backtrace for all `wasm` family targets

### DIFF
--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -174,6 +174,7 @@ cfg_if::cfg_if! {
         any(
             all(
                 unix,
+                not(target_family = "wasm"),
                 not(target_os = "emscripten"),
                 not(all(target_os = "ios", target_arch = "arm")),
             ),

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -438,7 +438,7 @@ cfg_if::cfg_if! {
         mod dbghelp;
         use dbghelp as imp;
     } else if #[cfg(all(
-        any(unix, all(windows, target_env = "gnu")),
+        any(all(unix, not(target_family = "wasm")), all(windows, target_env = "gnu")),
         not(target_vendor = "uwp"),
         not(target_os = "emscripten"),
         any(not(backtrace_in_libstd), feature = "backtrace"),


### PR DESCRIPTION
Particularly needed to support `wasm32-wali-linux-musl` appropriately