### PR TITLE
[AIX] Update backtrace to account for libc changes and fix XCOFF parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ checksum = "93563d740bc9ef04104f9ed6f86f1e3275c2cdafb95664e26584b9ca807a8ffe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"

--- a/src/symbolize/gimli/libs_aix.rs
+++ b/src/symbolize/gimli/libs_aix.rs
@@ -30,7 +30,7 @@ pub(super) fn native_libraries() -> Vec<Library> {
         loop {
             if libc::loadquery(
                 libc::L_GETINFO,
-                buffer.as_mut_ptr().cast::<libc::c_char>(),
+                buffer.as_mut_ptr().cast::<libc::c_void>(),
                 (mem::size_of::<libc::ld_info>() * buffer.len()) as u32,
             ) != -1
             {

--- a/src/symbolize/gimli/xcoff.rs
+++ b/src/symbolize/gimli/xcoff.rs
@@ -64,7 +64,7 @@ pub fn parse_xcoff(data: &[u8]) -> Option<Image> {
     let header = Xcoff::parse(data, &mut offset).ok()?;
     let _ = header.aux_header(data, &mut offset).ok()?;
     let sections = header.sections(data, &mut offset).ok()?;
-    if let Some(section) = sections.iter().find(|s| s.s_name().get(0..5) == b".text") {
+    if let Some(section) = sections.iter().find(|s| s.s_name().get(0..5) == Some(b".text")) {
         Some(Image {
             offset: section.s_scnptr() as usize,
             base: section.s_paddr() as u64,

--- a/src/symbolize/gimli/xcoff.rs
+++ b/src/symbolize/gimli/xcoff.rs
@@ -64,7 +64,10 @@ pub fn parse_xcoff(data: &[u8]) -> Option<Image> {
     let header = Xcoff::parse(data, &mut offset).ok()?;
     let _ = header.aux_header(data, &mut offset).ok()?;
     let sections = header.sections(data, &mut offset).ok()?;
-    if let Some(section) = sections.iter().find(|s| s.s_name().get(0..5) == Some(b".text")) {
+    if let Some(section) = sections
+        .iter()
+        .find(|s| s.s_name().get(0..5) == Some(b".text"))
+    {
         Some(Image {
             offset: section.s_scnptr() as usize,
             base: section.s_paddr() as u64,


### PR DESCRIPTION
This patch synchronizes AIX backtrace support with newer libc updates and fix type correctness issues:

- Bump libc to 0.2.175 to pick up latest AIX-related fixes.
- Update libc::loadquery buffer argument to use *mut c_void instead of *mut c_char, matching the current libc API.
- Fix XCOFF section name comparison to handle Option<&[u8]>.