### PR TITLE
use cfg_select instead of cfg_if

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -259,7 +259,7 @@ jobs:
         with:
           submodules: true
       - name: Install Rust
-        run: rustup update 1.88.0 --no-self-update && rustup default 1.88.0
+        run: rustup update 1.95 --no-self-update && rustup default 1.95
       - run: cargo build
 
   miri:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,6 @@ name = "as-if-std"
 version = "0.1.0"
 dependencies = [
  "addr2line",
- "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -36,7 +35,6 @@ name = "backtrace"
 version = "0.3.76"
 dependencies = [
  "addr2line",
- "cfg-if",
  "cpp_demangle",
  "dylib-dep",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ autoexamples = true
 autotests = true
 edition = "2024"
 exclude = ["/ci/"]
-rust-version = "1.88.0"
+rust-version = "1.95"
 
 [workspace]
 members = ['crates/cpp_smoke_test', 'crates/as-if-std']
@@ -26,7 +26,6 @@ exclude = [
 ]
 
 [dependencies]
-cfg-if = "1.0"
 rustc-demangle = "0.1.27"
 
 # Optionally enable the ability to serialize a `Backtrace`, controlled through
@@ -48,7 +47,7 @@ addr2line = { version = "0.25.0", default-features = false }
 libc = { version = "0.2.156", default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies.object]
-version = "0.39.0"
+version = "0.39.1"
 default-features = false
 features = ['read_core', 'elf', 'macho', 'pe', 'xcoff', 'unaligned', 'archive']
 

--- a/crates/as-if-std/Cargo.toml
+++ b/crates/as-if-std/Cargo.toml
@@ -12,7 +12,6 @@ doctest = false
 bench = false
 
 [dependencies]
-cfg-if = "1.0"
 rustc-demangle = "0.1.27"
 libc = { version = "0.2.156", default-features = false }
 

--- a/src/backtrace/libunwind.rs
+++ b/src/backtrace/libunwind.rs
@@ -177,9 +177,9 @@ mod uw {
         ) -> _Unwind_Reason_Code;
     }
 
-    cfg_if::cfg_if! {
+    cfg_select! {
         // available since GCC 4.2.0, should be fine for our purpose
-        if #[cfg(all(
+        all(
             not(all(target_os = "android", target_arch = "arm")),
             not(all(target_os = "freebsd", target_arch = "arm")),
             not(all(target_os = "linux", target_arch = "arm")),
@@ -187,7 +187,7 @@ mod uw {
             not(all(target_os = "rtems", target_arch = "arm")),
             not(all(target_os = "vita", target_arch = "arm")),
             not(all(target_os = "nuttx", target_arch = "arm")),
-        ))] {
+        ) => {
             unsafe extern "C" {
                 pub fn _Unwind_GetIP(ctx: *mut _Unwind_Context) -> libc::uintptr_t;
                 pub fn _Unwind_FindEnclosingFunction(pc: *mut c_void) -> *mut c_void;
@@ -213,7 +213,8 @@ mod uw {
                 }
                 unsafe { _Unwind_GetGR(ctx, 15) }
             }
-        } else {
+        }
+        _ => {
             use core::ptr::addr_of_mut;
 
             // On android and arm, the function `_Unwind_GetIP` and a bunch of

--- a/src/backtrace/mod.rs
+++ b/src/backtrace/mod.rs
@@ -163,42 +163,44 @@ mod sgx_image_base {
 #[cfg(all(target_env = "sgx", target_vendor = "fortanix", not(feature = "std")))]
 pub use sgx_image_base::imp::set_image_base;
 
-cfg_if::cfg_if! {
+cfg_select! {
     // This needs to come first, to ensure that
     // Miri takes priority over the host platform
-    if #[cfg(miri)] {
+    miri => {
         pub(crate) mod miri;
         use self::miri::trace as trace_imp;
         pub(crate) use self::miri::Frame as FrameImp;
-    } else if #[cfg(
-        any(
-            all(
-                unix,
-                not(target_os = "emscripten"),
-                not(all(target_os = "ios", target_arch = "arm")),
-            ),
-            all(
-                target_env = "sgx",
-                target_vendor = "fortanix",
-            ),
-        )
-    )] {
+    }
+    any(
+        all(
+            unix,
+            not(target_os = "emscripten"),
+            not(all(target_os = "ios", target_arch = "arm")),
+        ),
+        all(
+            target_env = "sgx",
+            target_vendor = "fortanix",
+        ),
+    ) => {
         mod libunwind;
         use self::libunwind::trace as trace_imp;
         pub(crate) use self::libunwind::Frame as FrameImp;
-    } else if #[cfg(all(windows, not(target_vendor = "uwp")))] {
-        cfg_if::cfg_if! {
-            if #[cfg(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "arm64ec"))] {
+    }
+    all(windows, not(target_vendor = "uwp")) => {
+        cfg_select! {
+            any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "arm64ec") => {
                 mod win64;
                 use self::win64::trace as trace_imp;
                 pub(crate) use self::win64::Frame as FrameImp;
-            } else if #[cfg(any(target_arch = "x86", target_arch = "arm"))] {
+            }
+            any(target_arch = "x86", target_arch = "arm") => {
                 mod win32;
                 use self::win32::trace as trace_imp;
                 pub(crate) use self::win32::Frame as FrameImp;
             }
         }
-    } else {
+    }
+    _ => {
         mod noop;
         use self::noop::trace as trace_imp;
         pub(crate) use self::noop::Frame as FrameImp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,20 +121,18 @@ pub use self::symbolize::clear_symbol_cache;
 mod print;
 pub use print::{BacktraceFmt, BacktraceFrameFmt, PrintFmt};
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
+cfg_select! {
+    feature = "std" => {
         pub use self::backtrace::trace;
         pub use self::symbolize::{resolve, resolve_frame};
         pub use self::capture::{Backtrace, BacktraceFrame, BacktraceSymbol};
         mod capture;
     }
+    _ => {}
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(all(target_env = "sgx", target_vendor = "fortanix", not(feature = "std")))] {
-        pub use self::backtrace::set_image_base;
-    }
-}
+#[cfg(all(target_env = "sgx", target_vendor = "fortanix", not(feature = "std")))]
+pub use self::backtrace::set_image_base;
 
 #[cfg(feature = "std")]
 mod lock {

--- a/src/symbolize/gimli.rs
+++ b/src/symbolize/gimli.rs
@@ -25,14 +25,13 @@ mod mystd {
 #[cfg(not(backtrace_in_libstd))]
 extern crate std as mystd;
 
-cfg_if::cfg_if! {
-    if #[cfg(windows)] {
+cfg_select! {
+    windows => {
         #[path = "gimli/mmap_windows.rs"]
         mod mmap;
-    } else if #[cfg(target_vendor = "apple")] {
-        #[path = "gimli/mmap_unix.rs"]
-        mod mmap;
-    } else if #[cfg(any(
+    }
+    any(
+        target_vendor = "apple",
         target_os = "android",
         target_os = "freebsd",
         target_os = "fuchsia",
@@ -44,10 +43,11 @@ cfg_if::cfg_if! {
         target_os = "illumos",
         target_os = "aix",
         target_os = "cygwin",
-    ))] {
+    ) => {
         #[path = "gimli/mmap_unix.rs"]
         mod mmap;
-    } else {
+    }
+    _ => {
         #[path = "gimli/mmap_fake.rs"]
         mod mmap;
     }
@@ -195,33 +195,39 @@ fn mmap(path: &Path) -> Option<Mmap> {
     unsafe { Mmap::map(&file, len, 0) }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(any(windows, target_os = "cygwin"))] {
+cfg_select! {
+    any(windows, target_os = "cygwin") => {
         mod coff;
         use self::coff::{handle_split_dwarf, Object};
-    } else if #[cfg(any(target_vendor = "apple"))] {
+    }
+    target_vendor = "apple" => {
         mod macho;
         use self::macho::{handle_split_dwarf, Object};
-    } else if #[cfg(target_os = "aix")] {
+    }
+    target_os = "aix" => {
         mod xcoff;
         use self::xcoff::{handle_split_dwarf, Object};
-    } else {
+    }
+    _ => {
         mod elf;
         use self::elf::{handle_split_dwarf, Object};
     }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(any(windows, target_os = "cygwin"))] {
+cfg_select! {
+    any(windows, target_os = "cygwin") => {
         mod libs_windows;
         use libs_windows::native_libraries;
-    } else if #[cfg(target_vendor = "apple")] {
+    }
+    target_vendor = "apple" => {
         mod libs_macos;
         use libs_macos::native_libraries;
-    } else if #[cfg(target_os = "illumos")] {
+    }
+    target_os = "illumos" => {
         mod libs_illumos;
         use libs_illumos::native_libraries;
-    } else if #[cfg(all(
+    }
+    all(
         any(
             target_os = "linux",
             target_os = "fuchsia",
@@ -233,22 +239,26 @@ cfg_if::cfg_if! {
             target_os = "android",
         ),
         not(target_env = "uclibc"),
-    ))] {
+    ) => {
         mod libs_dl_iterate_phdr;
         use libs_dl_iterate_phdr::native_libraries;
         #[path = "gimli/parse_running_mmaps_unix.rs"]
         mod parse_running_mmaps;
-    } else if #[cfg(target_env = "libnx")] {
+    }
+    target_env = "libnx" => {
         mod libs_libnx;
         use libs_libnx::native_libraries;
-    } else if #[cfg(target_os = "haiku")] {
+    }
+    target_os = "haiku" => {
         mod libs_haiku;
         use libs_haiku::native_libraries;
-    } else if #[cfg(target_os = "aix")] {
+    }
+    target_os = "aix" => {
         mod libs_aix;
         use libs_aix::native_libraries;
-    } else {
-        // Everything else should doesn't know how to load native libraries.
+    }
+    _ => {
+        // Everything else doesn't know how to load native libraries.
         fn native_libraries() -> Vec<Library> {
             Vec::new()
         }
@@ -316,12 +326,14 @@ struct LibrarySegment {
 }
 
 fn create_mapping(lib: &Library) -> Option<Mapping> {
-    cfg_if::cfg_if! {
-        if #[cfg(target_os = "aix")] {
+    cfg_select! {
+        target_os = "aix" => {
             Mapping::new(lib.name.as_ref(), &lib.member_name)
-        } else if #[cfg(target_os = "android")] {
+        }
+        target_os = "android" => {
             Mapping::new_android(lib.name.as_ref(), lib.zip_offset)
-        } else {
+        }
+        _ => {
             Mapping::new(lib.name.as_ref())
         }
     }

--- a/src/symbolize/gimli/elf.rs
+++ b/src/symbolize/gimli/elf.rs
@@ -397,24 +397,22 @@ fn decompress_zstd(mut input: &[u8], mut output: &mut [u8]) -> Option<()> {
 const DEBUG_PATH: &str = "/usr/lib/debug";
 
 fn debug_path_exists() -> bool {
-    cfg_if::cfg_if! {
-        if #[cfg(any(target_os = "freebsd", target_os = "hurd", target_os = "linux"))] {
-            use core::sync::atomic::{AtomicU8, Ordering};
-            static DEBUG_PATH_EXISTS: AtomicU8 = AtomicU8::new(0);
+    if cfg!(any(
+        target_os = "freebsd",
+        target_os = "hurd",
+        target_os = "linux"
+    )) {
+        use core::sync::atomic::{AtomicU8, Ordering};
+        static DEBUG_PATH_EXISTS: AtomicU8 = AtomicU8::new(0);
 
-            let mut exists = DEBUG_PATH_EXISTS.load(Ordering::Relaxed);
-            if exists == 0 {
-                exists = if Path::new(DEBUG_PATH).is_dir() {
-                    1
-                } else {
-                    2
-                };
-                DEBUG_PATH_EXISTS.store(exists, Ordering::Relaxed);
-            }
-            exists == 1
-        } else {
-            false
+        let mut exists = DEBUG_PATH_EXISTS.load(Ordering::Relaxed);
+        if exists == 0 {
+            exists = if Path::new(DEBUG_PATH).is_dir() { 1 } else { 2 };
+            DEBUG_PATH_EXISTS.store(exists, Ordering::Relaxed);
         }
+        exists == 1
+    } else {
+        false
     }
 }
 

--- a/src/symbolize/mod.rs
+++ b/src/symbolize/mod.rs
@@ -1,11 +1,7 @@
 use core::{fmt, str};
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
-        use std::path::Path;
-        use std::prelude::v1::*;
-    }
-}
+#[cfg(feature = "std")]
+use std::{path::Path, prelude::v1::*};
 
 use super::backtrace::Frame;
 use super::types::BytesOrWideString;
@@ -277,21 +273,18 @@ impl fmt::Debug for Symbol {
     }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "cpp_demangle")] {
-        // Maybe a parsed C++ symbol, if parsing the mangled symbol as Rust
-        // failed.
-        struct OptionCppSymbol<'a>(Option<::cpp_demangle::BorrowedSymbol<'a>>);
+// Maybe a parsed C++ symbol, if parsing the mangled symbol as Rust failed.
+#[cfg(feature = "cpp_demangle")]
+struct OptionCppSymbol<'a>(Option<::cpp_demangle::BorrowedSymbol<'a>>);
 
-        impl<'a> OptionCppSymbol<'a> {
-            fn parse(input: &'a [u8]) -> OptionCppSymbol<'a> {
-                OptionCppSymbol(::cpp_demangle::BorrowedSymbol::new(input).ok())
-            }
+#[cfg(feature = "cpp_demangle")]
+impl<'a> OptionCppSymbol<'a> {
+    fn parse(input: &'a [u8]) -> OptionCppSymbol<'a> {
+        OptionCppSymbol(::cpp_demangle::BorrowedSymbol::new(input).ok())
+    }
 
-            fn none() -> OptionCppSymbol<'a> {
-                OptionCppSymbol(None)
-            }
-        }
+    fn none() -> OptionCppSymbol<'a> {
+        OptionCppSymbol(None)
     }
 }
 
@@ -430,22 +423,25 @@ pub fn clear_symbol_cache() {
     }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(miri)] {
+cfg_select! {
+    miri => {
         mod miri;
         use miri as imp;
-    } else if #[cfg(all(windows, target_env = "msvc", not(target_vendor = "uwp")))] {
+    }
+    all(windows, target_env = "msvc", not(target_vendor = "uwp")) => {
         mod dbghelp;
         use dbghelp as imp;
-    } else if #[cfg(all(
+    }
+    all(
         any(unix, all(windows, target_env = "gnu")),
         not(target_vendor = "uwp"),
         not(target_os = "emscripten"),
         any(not(backtrace_in_libstd), feature = "backtrace"),
-    ))] {
+    ) => {
         mod gimli;
         use gimli as imp;
-    } else {
+    }
+    _ => {
         mod noop;
         use noop as imp;
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,13 +1,14 @@
 //! Platform dependent types.
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "std")] {
+cfg_select! {
+    feature = "std" => {
         use std::borrow::Cow;
         use std::fmt;
         use std::path::PathBuf;
         use std::prelude::v1::*;
         use std::str;
     }
+    _ => {}
 }
 
 /// A platform independent representation of a string. When working with `std`


### PR DESCRIPTION
Now that cfg_select is stable since 1.95, we can replace cfg_if. One difference is that cfg_select needs one branch to match. Therefore an empty default branch is sometimes needed.