### PR TITLE
Update `object` to 0.40.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+checksum = "dd229a0361b9d0d4396176e02d65897f487eebeab7caa6d443855ee152ca0b9c"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ addr2line = { version = "0.25.0", default-features = false }
 libc = { version = "0.2.156", default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies.object]
-version = "0.39.0"
+version = "0.40.0"
 default-features = false
 features = ['read_core', 'elf', 'macho', 'pe', 'xcoff', 'unaligned', 'archive']
 

--- a/crates/as-if-std/Cargo.toml
+++ b/crates/as-if-std/Cargo.toml
@@ -22,7 +22,7 @@ ruzstd = { version = "0.8.1", optional = true, default-features = false }
 addr2line = { version = "0.25.0", optional = true, default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies.object]
-version = "0.39.0"
+version = "0.40.0"
 default-features = false
 optional = true
 features = ['read_core', 'elf', 'macho', 'pe', 'xcoff', 'unaligned', 'archive']

--- a/src/print/fuchsia.rs
+++ b/src/print/fuchsia.rs
@@ -200,7 +200,7 @@ impl<'a> Iterator for NoteIter<'a> {
         Some(Note {
             name: name,
             desc: desc,
-            tipe: nhdr.n_type.get(NE),
+            tipe: nhdr.n_type.get(NE).0,
         })
     }
 }

--- a/src/symbolize/gimli/coff.rs
+++ b/src/symbolize/gimli/coff.rs
@@ -6,7 +6,7 @@ use core::convert::TryFrom;
 use object::LittleEndian as LE;
 use object::pe::{ImageDosHeader, ImageSymbol};
 use object::read::StringTable;
-use object::read::coff::ImageSymbol as _;
+use object::read::coff::Symbol as _;
 use object::read::pe::{ImageNtHeaders, ImageOptionalHeader, SectionTable};
 
 #[cfg(target_pointer_width = "32")]

--- a/src/symbolize/gimli/elf.rs
+++ b/src/symbolize/gimli/elf.rs
@@ -219,8 +219,7 @@ impl<'a> Object<'a> {
             // Check for DWARF-standard (gABI) compression, i.e., as generated
             // by ld's `--compress-debug-sections=zlib-gabi` and
             // `--compress-debug-sections=zstd` flags.
-            let flags: u64 = section.sh_flags(self.endian).into();
-            if (flags & u64::from(SHF_COMPRESSED)) == 0 {
+            if !section.sh_flags(self.endian).contains(SHF_COMPRESSED) {
                 // Not compressed.
                 return Some(data.0);
             }

--- a/src/symbolize/gimli/macho.rs
+++ b/src/symbolize/gimli/macho.rs
@@ -163,7 +163,7 @@ fn find_header(data: &'_ [u8]) -> Option<(&'_ Mach, &'_ [u8])> {
 pub struct Object<'a> {
     endian: NativeEndian,
     data: &'a [u8],
-    dwarf: Option<&'a [MachSection]>,
+    dwarf: Option<(&'a MachSegment, &'a [MachSection])>,
     syms: Vec<(&'a [u8], u64)>,
     syms_sort_by_name: bool,
     // Only set for executables/libraries, and not the source object files.
@@ -185,7 +185,10 @@ impl<'a> Object<'a> {
             if let Some((segment, section_data)) = MachSegment::from_command(command).ok()? {
                 // Object files should have all sections in a single unnamed segment load command.
                 if segment.name() == b"__DWARF" || (is_object && segment.name() == b"") {
-                    dwarf = segment.sections(endian, section_data).ok();
+                    dwarf = segment
+                        .sections(endian, section_data)
+                        .ok()
+                        .map(|sections| (segment, sections));
                 }
             } else if let Some(symtab) = command.symtab().ok()? {
                 let symbols = symtab.symbols::<Mach, _>(endian, data).ok()?;
@@ -228,16 +231,19 @@ impl<'a> Object<'a> {
 
     pub fn section(&self, _: &Stash, name: &str) -> Option<&'a [u8]> {
         let name = name.as_bytes();
-        let dwarf = self.dwarf?;
-        let section = dwarf.into_iter().find(|section| {
-            let section_name = section.name();
-            section_name == name || {
-                section_name.starts_with(b"__")
-                    && name.starts_with(b".")
-                    && &section_name[2..] == &name[1..]
-            }
-        })?;
-        Some(section.data(self.endian, self.data).ok()?)
+        let (segment, sections) = self.dwarf?;
+        let (section, offset) = segment
+            .section_offsets(self.endian, sections)
+            .filter_map(|section| section.ok())
+            .find(|(section, _offset)| {
+                let section_name = section.name();
+                section_name == name || {
+                    section_name.starts_with(b"__")
+                        && name.starts_with(b".")
+                        && &section_name[2..] == &name[1..]
+                }
+            })?;
+        Some(section.data(self.endian, self.data, offset).ok()?)
     }
 
     pub fn search_symtab<'b>(&'b self, addr: u64) -> Option<&'b [u8]> {

--- a/src/symbolize/gimli/xcoff.rs
+++ b/src/symbolize/gimli/xcoff.rs
@@ -103,10 +103,8 @@ impl<'a> Object<'a> {
     fn get_concrete_size(file: &XcoffFile<'a, Xcoff>, sym: &XcoffSymbol<'a, '_, Xcoff>) -> u64 {
         match sym.flags() {
             SymbolFlags::Xcoff {
-                n_sclass: _,
-                x_smtyp: _,
-                x_smclas: _,
                 containing_csect: Some(index),
+                ..
             } => {
                 if let Ok(tgt_sym) = file.symbol_by_index(index) {
                     Self::get_concrete_size(file, &tgt_sym)


### PR DESCRIPTION
The Mach-O change also means it handles file offsets larger than 32-bit, which can happen for large dSYM files.